### PR TITLE
Add native extension support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,4 +49,5 @@ class HelloApp extends App {
 - **[Modifiers](modifiers.md)** &mdash; 27+ view modifiers reference.
 - **[State](state/README.md)** &mdash; State management, bindings, and observables.
 - **[Bridge](bridge.md)** &mdash; Transparent Haxe/C++ bridge (automatic closures + explicit exports).
+- **[Native Extensions](native-extensions.md)** &mdash; Custom Swift files and SPM packages.
 - **[Examples](examples/README.md)** &mdash; 13 annotated example apps.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
   - [Observable](state/observable.md)
 - [Components](components.md)
 - [Bridge](bridge.md)
+- [Native Extensions](native-extensions.md)
 - [CLI Reference](cli.md)
 - [Platforms](platforms.md)
 - [Metadata](metadata.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,8 +21,9 @@ This scaffolds a ready-to-build project:
 MyApp/
   src/
     MyApp.hx          # Your app entry point
+  swift/               # Custom Swift files (optional)
   build.hxml           # Haxe build configuration
-  project.yml          # Xcode project spec (xcodegen)
+  sui.json             # Project configuration
 ```
 
 ## Write Your App

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -99,7 +99,29 @@ public static function calc(items:Array<Int>):Int {
 
 ## @:swiftView
 
-Marks a class as generating a SwiftUI View struct. Applied automatically to `ViewComponent` subclasses but can be used explicitly for advanced control.
+References a SwiftUI View struct by name. Use this to wrap a native SwiftUI view (defined in your `swift/` directory) so it can be used from Haxe.
+
+```haxe
+// swift/RatingStars.swift defines: struct RatingStars: View { let count: Int; ... }
+
+@:swiftView("RatingStars")
+class RatingStars extends View {
+    public var count:Int;
+    public function new(@:swiftLabel("count") count:Int) {
+        super();
+        this.count = count;
+    }
+}
+
+// Usage in body():
+new RatingStars(5)
+```
+
+**Generated Swift:** `RatingStars(count: 5)`
+
+No Swift struct is generated for `@:swiftView` classes &mdash; it references your existing native implementation. Also applied automatically to `ViewComponent` subclasses.
+
+See [Native Extensions](native-extensions.md) for full details.
 
 ## Summary
 
@@ -109,4 +131,4 @@ Marks a class as generating a SwiftUI View struct. Applied automatically to `Vie
 | `@:swiftBinding` | Component property / constructor param | Generate `@Binding var` |
 | `@:swiftLabel` | Constructor parameter | Set Swift argument label |
 | `@:swiftName` | Function / type | Override generated Swift name |
-| `@:swiftView` | Class | Mark as SwiftUI View struct |
+| `@:swiftView` | Class | Reference a native SwiftUI View by name |

--- a/docs/native-extensions.md
+++ b/docs/native-extensions.md
@@ -1,0 +1,131 @@
+# Native Extensions
+
+sui supports custom Swift code and Swift Package Manager dependencies alongside your Haxe app.
+
+## Custom Swift Files
+
+Drop `.swift` files into the `swift/` directory in your project root. They're automatically compiled into your app.
+
+```
+MyApp/
+  src/
+    MyApp.hx
+  swift/
+    MyNativeChart.swift
+  build.hxml
+  sui.json
+```
+
+### Example: Custom SwiftUI View
+
+**swift/GradientCard.swift:**
+```swift
+import SwiftUI
+
+struct GradientCard: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(
+                LinearGradient(
+                    colors: [.blue, .purple],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .foregroundColor(.white)
+            .cornerRadius(12)
+    }
+}
+```
+
+### Referencing from Haxe
+
+Use `@:swiftView` to create a Haxe wrapper, then use it in `body()` like any built-in view:
+
+```haxe
+@:swiftView("GradientCard")
+class GradientCard extends View {
+    public var title:String;
+    public function new(@:swiftLabel("title") title:String) {
+        super();
+        this.title = title;
+    }
+}
+
+class MyApp extends App {
+    // ...
+    override function body():View {
+        return new VStack([
+            new GradientCard("Welcome"),
+            new GradientCard("Dashboard")
+        ]);
+    }
+}
+```
+
+**Generated Swift:** `GradientCard(title: "Welcome")`
+
+The `@:swiftView` class doesn't generate a Swift struct &mdash; it references the one in your `swift/` directory.
+
+## SPM Dependencies
+
+Declare Swift packages in `sui.json`:
+
+```json
+{
+    "appName": "MyApp",
+    "bundleIdentifier": "com.example.myapp",
+    "bundleIdPrefix": "com.example",
+    "swiftPackages": [
+        {
+            "url": "https://github.com/airbnb/lottie-ios",
+            "from": "4.4.1",
+            "product": "Lottie"
+        }
+    ]
+}
+```
+
+Each entry needs:
+
+| Field | Description |
+|-------|-------------|
+| `url` | Git URL of the Swift package |
+| `from` | Minimum version (semver) |
+| `product` | Product name to link |
+
+### Using SPM Types in Custom Views
+
+Your `swift/` files can import and use any declared package:
+
+```swift
+import SwiftUI
+import Lottie
+
+struct AnimatedLogo: View {
+    var body: some View {
+        LottieView(animation: .named("logo"))
+            .looping()
+            .frame(width: 200, height: 200)
+    }
+}
+```
+
+Then reference it from Haxe with `@:swiftView("AnimatedLogo")`.
+
+## How It Works
+
+```
+swift/ files        --> copied to build/Sources/  --> compiled by Xcode
+sui.json packages   --> project.yml packages block --> resolved by SPM
+@:swiftView classes --> Swift instantiation call   --> references your structs
+```
+
+- Swift files in `swift/` are copied verbatim &mdash; no code generation
+- `@:swiftView` classes don't generate Swift structs &mdash; they reference yours
+- SPM packages are resolved at build time by Xcode
+- Custom Swift code has full access to SwiftUI, SPM packages, and generated app code

--- a/tools/cli/Build.hx
+++ b/tools/cli/Build.hx
@@ -168,6 +168,9 @@ class Build {
         // Copy runtime Swift files from sui library
         copyRuntimeFiles(buildDir);
 
+        // Copy user-provided Swift files from swift/ directory
+        copyUserSwiftFiles(cwd, buildDir);
+
         // Generate project.yml
         File.saveContent('$buildDir/project.yml', generateProjectYaml(config, platform, forDevice, isBridgeApp));
 
@@ -327,16 +330,36 @@ class Build {
         }
     }
 
+    static function copyUserSwiftFiles(cwd:String, buildDir:String) {
+        var swiftDir = '$cwd/swift';
+        if (FileSystem.exists(swiftDir)) {
+            for (file in FileSystem.readDirectory(swiftDir)) {
+                if (file.endsWith(".swift")) {
+                    File.copy('$swiftDir/$file', '$buildDir/Sources/$file');
+                }
+            }
+        }
+    }
+
     public static function readProjectConfig(cwd:String):ProjectConfig {
         var configPath = '$cwd/sui.json';
         if (FileSystem.exists(configPath)) {
             var content = File.getContent(configPath);
             var json = haxe.Json.parse(content);
+            var packages:Array<SwiftPackage> = null;
+            if (json.swiftPackages != null) {
+                packages = [];
+                var arr:Array<Dynamic> = json.swiftPackages;
+                for (pkg in arr) {
+                    packages.push({url: pkg.url, from: pkg.from, product: pkg.product});
+                }
+            }
             return {
                 appName: json.appName,
                 bundleIdentifier: json.bundleIdentifier,
                 bundleIdPrefix: json.bundleIdPrefix != null ? json.bundleIdPrefix : "com.example",
                 teamId: json.teamId,
+                swiftPackages: packages,
             };
         }
 
@@ -441,6 +464,14 @@ class Build {
             var stat = FileSystem.stat('$cwd/build.hxml');
             newestSource = Math.max(newestSource, stat.mtime.getTime());
         }
+        // Check sui.json
+        if (FileSystem.exists('$cwd/sui.json')) {
+            var stat = FileSystem.stat('$cwd/sui.json');
+            newestSource = Math.max(newestSource, stat.mtime.getTime());
+        }
+        // Check user Swift files
+        var userSwiftDir = '$cwd/swift';
+        if (FileSystem.exists(userSwiftDir)) newestSource = Math.max(newestSource, newestModTime(userSwiftDir, ".swift"));
 
         if (newestSource == 0) return false;
 
@@ -540,7 +571,18 @@ class Build {
 ';
         }
 
-        return 'name: ${config.appName}
+        var packagesBlock = "";
+        var depsBlock = "    dependencies: []\n";
+        if (config.swiftPackages != null && config.swiftPackages.length > 0) {
+            packagesBlock = "packages:\n";
+            depsBlock = "    dependencies:\n";
+            for (pkg in config.swiftPackages) {
+                packagesBlock += '  ${pkg.product}:\n    url: ${pkg.url}\n    from: ${pkg.from}\n';
+                depsBlock += '      - package: ${pkg.product}\n';
+            }
+        }
+
+        return '${packagesBlock}name: ${config.appName}
 options:
   bundleIdPrefix: ${config.bundleIdPrefix}
   deploymentTarget:
@@ -561,8 +603,7 @@ targets:
       INFOPLIST_KEY_UILaunchScreen_Generation: true
       INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
       INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-$signing$bridge    dependencies: []
-';
+$signing$bridge$depsBlock';
     }
 }
 
@@ -571,4 +612,11 @@ typedef ProjectConfig = {
     bundleIdentifier:String,
     bundleIdPrefix:String,
     ?teamId:String,
+    ?swiftPackages:Array<SwiftPackage>,
+}
+
+typedef SwiftPackage = {
+    url:String,
+    from:String,
+    product:String,
 }

--- a/tools/cli/Init.hx
+++ b/tools/cli/Init.hx
@@ -22,6 +22,7 @@ class Init {
         // Create directory structure
         FileSystem.createDirectory(projectDir);
         FileSystem.createDirectory('$projectDir/src');
+        FileSystem.createDirectory('$projectDir/swift');
 
         // Create sui.json
         // Try auto-detecting team ID for device builds


### PR DESCRIPTION
## Summary

- Users can drop `.swift` files into a `swift/` directory and have them automatically included in the build
- SPM dependencies can be declared in `sui.json` via `swiftPackages` field
- `@:swiftView` metadata documented for referencing native SwiftUI views from Haxe

## Test plan

- [ ] Scaffold a new project with `sui init` and verify `swift/` directory is created
- [ ] Add a `.swift` file to `swift/`, build, and confirm it's copied to `build/{platform}/Sources/`
- [ ] Add `swiftPackages` to `sui.json` and verify `project.yml` contains correct xcodegen SPM format
- [ ] Verify `@:swiftView` classes reference native views without generating duplicate Swift structs

🤖 Generated with [Claude Code](https://claude.com/claude-code)