### PR TITLE
Support multiple arguments in BridgeCall and BridgeCallLoading

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -110,11 +110,15 @@ new Button("Greet", () -> {
 ### With BridgeCall
 
 ```haxe
-// With @:bridge
+// Single argument
 new Button("Greet", null,
     StateAction.BridgeCall("result", "greet", "World"))
 
-// Without @:bridge
+// Multiple arguments
+new Button("Login", null,
+    StateAction.BridgeCall("result", "doLogin", ["https://api.example.com", "user@email.com", "pass123"]))
+
+// Without @:bridge — same logic via closure
 new Button("Greet", () -> result.set(greet("World")))
 ```
 
@@ -123,21 +127,16 @@ new Button("Greet", () -> result.set(greet("World")))
 For slow operations, show a loading state while the bridge call runs:
 
 ```haxe
-// With @:bridge — framework handles loading state and async
+// Single argument
 new Button("Fetch Data", null,
     StateAction.BridgeCallLoading("result", "Loading...", "fetchUrl", "https://example.com"))
 
-// Without @:bridge — handle loading state yourself in a closure
-new Button("Fetch Data", () -> {
-    result.set("Loading...");
-    var http = new haxe.Http("https://example.com");
-    http.onData = (d) -> result.set(d.length > 500 ? d.substr(0, 500) + "..." : d);
-    http.onError = (e) -> result.set("Error: " + e);
-    http.request(false);
-})
+// Multiple arguments
+new Button("Login", null,
+    StateAction.BridgeCallLoading("result", "Logging in...", "doLogin", ["https://api.example.com", "user@email.com", "pass123"]))
 ```
 
-The `@:bridge` + `BridgeCallLoading` version generates Swift that wraps the call in a `Task { @MainActor in }`, giving you loading state for free. The closure version does the same thing manually.
+The `BridgeCallLoading` version sets the loading text immediately, then runs the bridge call in a background task and updates the state when done.
 
 ## How It Works
 

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1260,14 +1260,12 @@ class SwiftGenerator {
                                     case "CustomSwift": p0 != null ? p0 : "// custom";
                                     case "BridgeCall":
                                         var fnName = if (args.length > 1) extractString(args[1]) else "unknown";
-                                        var fnArg = if (args.length > 2) extractString(args[2]) else null;
-                                        var argStr = fnArg != null ? '"${esc(fnArg)}"' : "";
+                                        var argStr = if (args.length > 2) extractBridgeArgs(args[2]) else "";
                                         'Task.detached { let r = HaxeBridgeC.${fnName}(${argStr}); await MainActor.run { ${p0} = r } }';
                                     case "BridgeCallLoading":
                                         var loadingVal = if (args.length > 1) extractString(args[1]) else "Loading...";
                                         var fnName = if (args.length > 2) extractString(args[2]) else "unknown";
-                                        var fnArg = if (args.length > 3) extractString(args[3]) else null;
-                                        var argStr = fnArg != null ? '"${esc(fnArg)}"' : "";
+                                        var argStr = if (args.length > 3) extractBridgeArgs(args[3]) else "";
                                         '${p0} = "${esc(loadingVal)}"; Task.detached { let r = HaxeBridgeC.${fnName}(${argStr}); await MainActor.run { ${p0} = r } }';
                                     default: null;
                                 }
@@ -1455,6 +1453,27 @@ class SwiftGenerator {
             case TCast(e, _): extractConstant(e);
             case TParenthesis(e): extractConstant(e);
             default: null;
+        }
+    }
+
+    /** Extract bridge call arguments: supports a single string or an array of constants. **/
+    static function extractBridgeArgs(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "";
+        var e = unwrap(expr);
+        switch (e.expr) {
+            case TArrayDecl(elements):
+                var parts:Array<String> = [];
+                for (el in elements) {
+                    var c = extractConstant(el);
+                    if (c != null) parts.push(c);
+                }
+                return parts.join(", ");
+            default:
+                var s = extractString(expr);
+                if (s != null) return '"${esc(s)}"';
+                var c = extractConstant(expr);
+                if (c != null) return c;
+                return "";
         }
     }
 

--- a/src/sui/state/StateAction.hx
+++ b/src/sui/state/StateAction.hx
@@ -27,29 +27,33 @@ enum StateAction {
         Call a @:bridge function asynchronously and assign the result to a state variable.
         Runs in a Swift Task so the UI stays responsive.
 
-        Usage: BridgeCall("resultState", "bridgeFunctionName", "arg")
+        Single arg:  BridgeCall("result", "greet", "World")
+        Multi arg:   BridgeCall("result", "doLogin", ["url", "email", "pass"])
 
         Generates:
         ```swift
-        Task { @MainActor in
-            resultState = HaxeBridgeC.bridgeFunctionName("arg")
+        Task.detached {
+            let r = HaxeBridgeC.greet("World")
+            await MainActor.run { result = r }
         }
         ```
     **/
-    BridgeCall(stateName:String, functionName:String, arg:String);
+    BridgeCall(stateName:String, functionName:String, args:Dynamic);
 
     /**
         Like BridgeCall but sets a loading value immediately before the async call.
 
-        Usage: BridgeCallLoading("resultState", "Loading...", "fetchData", "https://url")
+        Single arg:  BridgeCallLoading("result", "Loading...", "fetchData", "https://url")
+        Multi arg:   BridgeCallLoading("result", "Loading...", "doLogin", ["url", "email", "pass"])
 
         Generates:
         ```swift
-        resultState = "Loading..."
-        Task { @MainActor in
-            resultState = HaxeBridgeC.fetchData("https://url")
+        result = "Loading..."
+        Task.detached {
+            let r = HaxeBridgeC.doLogin("url", "email", "pass")
+            await MainActor.run { result = r }
         }
         ```
     **/
-    BridgeCallLoading(stateName:String, loadingValue:String, functionName:String, arg:String);
+    BridgeCallLoading(stateName:String, loadingValue:String, functionName:String, args:Dynamic);
 }


### PR DESCRIPTION
## Summary

- Change `BridgeCall` and `BridgeCallLoading` arg type from `String` to `Dynamic`, accepting both a single string and an array
- Add `extractBridgeArgs()` helper in SwiftGenerator to handle both `"arg"` and `["arg1", "arg2"]` forms
- Update bridge docs with multi-arg examples

Closes #3

## Test plan

- [ ] Single-arg `BridgeCall("result", "greet", "World")` generates `HaxeBridgeC.greet("World")`
- [ ] Multi-arg `BridgeCall("result", "doLogin", ["url", "email", "pass"])` generates `HaxeBridgeC.doLogin("url", "email", "pass")`
- [ ] `BridgeCallLoading` works the same way for both forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)