### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Haxe
+        uses: kmaref/setup-haxe@v1
+        with:
+          haxe-version: 4.3.6
+
+      - name: Install hxcpp
+        run: |
+          haxelib install hxcpp --quiet
+          haxelib dev sui .
+
+      - name: Run tests
+        run: bash tests/run_tests.sh

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -82,7 +82,7 @@ fi
 echo ""
 echo "--- Test 7: CLI compilation ---"
 cd ..
-if haxe -cp tools -cp src -main tools.cli.CLI -neko /private/tmp/claude/cli_test.n 2>&1; then
+if haxe -cp tools -cp src -main tools.cli.CLI -neko "${TMPDIR:-/tmp}/cli_test.n" 2>&1; then
     echo "PASS: CLI compiles"
     PASS=$((PASS + 1))
 else


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` that runs the existing test suite on every push to main and on PRs
- Runs on `macos-latest` with Haxe 4.3.6 and hxcpp
- Tests: Swift code generation (diff against expected output) + CLI compilation
- Fix hardcoded `/private/tmp/claude/` path in test script to use `$TMPDIR`

## Test plan

- [ ] CI runs on this PR itself
- [ ] Tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)