### PR TITLE
Add State.setByName() for multi-state updates

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -203,6 +203,23 @@ class BridgeApp extends App {
 }
 ```
 
+## Multi-State Updates with State.setByName
+
+When a bridge function needs to update multiple state variables, use `State.setByName()` from a closure:
+
+```haxe
+new Button("Login", () -> {
+    State.setByName("status", "Logging in...");
+    var result = doLogin(email.get(), password.get());
+    State.setByName("userName", result.name);
+    State.setByName("mailboxCount", Std.string(result.mailboxes));
+    State.setByName("isLoggedIn", "true");
+    State.setByName("status", "Welcome!");
+})
+```
+
+Each `setByName` call immediately pushes the value to SwiftUI. This is the same mechanism that `State.set()` uses internally, but lets you target any state variable by name without needing a reference to the `State<T>` instance.
+
 ## Key Points
 
 - **Most bridging is automatic** &mdash; closures and `State.set()` just work
@@ -211,3 +228,4 @@ class BridgeApp extends App {
 - They can accept and return basic types (`String`, `Int`, `Float`, `Bool`)
 - The generated bridge uses `HaxeBridgeC.functionName()` in Swift
 - Use `BridgeCallLoading` for operations that take time
+- Use `State.setByName()` to update multiple states from a single closure

--- a/src/sui/state/State.hx
+++ b/src/sui/state/State.hx
@@ -55,4 +55,22 @@ class State<T> {
     public function onValueChanged(callback:T->Void):Void {
         onChange = callback;
     }
+
+    /**
+        Update a SwiftUI state variable by name from Haxe.
+        Useful in bridge function closures to update multiple states at once:
+
+        ```haxe
+        new Button("Login", () -> {
+            var result = doLogin(email.get(), password.get());
+            State.setByName("userName", result.name);
+            State.setByName("isLoggedIn", "true");
+        })
+        ```
+    **/
+    public static function setByName(key:String, value:String):Void {
+        #if cpp
+        untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', key, value);
+        #end
+    }
 }


### PR DESCRIPTION
## Summary

- Add `State.setByName(key, value)` static method that pushes a value to SwiftUI state by variable name
- Enables bridge closures to update multiple state variables in a single call without `@:bridge` or `BridgeCallLoading`
- Documents the pattern in bridge docs

Closes #4

## Test plan

- [ ] `State.setByName("varName", "value")` compiles and calls `_hxsui_notify_swift`
- [ ] Multiple `setByName` calls in a closure each update their respective SwiftUI state
- [ ] Existing `State.set()` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)