### PR TITLE
Add SecureField view for password inputs

### DIFF
--- a/docs/views/README.md
+++ b/docs/views/README.md
@@ -17,6 +17,7 @@ sui provides 22 built-in views that map directly to SwiftUI components.
 | `Image` | Display | `Image` | Image display |
 | `Button` | Control | `Button` | Tappable action |
 | `TextField` | Control | `TextField` | Text input |
+| `SecureField` | Control | `SecureField` | Password input |
 | `Toggle` | Control | `Toggle` | Boolean switch |
 | `Slider` | Control | `Slider` | Range input |
 | `Picker` | Control | `Picker` | Selection control |

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -62,6 +62,24 @@ new TextField("Enter your name...", "username")
 | `TextFieldStyleValue.RoundedBorder` | Rounded border style |
 | `TextFieldStyleValue.Plain` | No decoration |
 
+## SecureField
+
+A password input field that hides user input. Same API as `TextField`.
+
+```haxe
+new SecureField("Password", "password")
+    .textFieldStyle(TextFieldStyleValue.RoundedBorder)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `placeholder` | `String` | Placeholder text |
+| `textBinding` | `String` | Name of the `@State var` (String) to bind to |
+
+Supports the same `textFieldStyle` modifier as `TextField`.
+
 ## Toggle
 
 A boolean switch bound to a `@State` bool.

--- a/src/sui/ui/SecureField.hx
+++ b/src/sui/ui/SecureField.hx
@@ -1,0 +1,22 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+   A password input field that hides user input.
+   Maps to SwiftUI's `SecureField`.
+
+   The `textBinding` parameter is the name of a `@State` String variable to bind to.
+**/
+@:swiftView("SecureField")
+class SecureField extends View {
+    public var placeholder:String;
+    public var textBinding:String;
+
+    public function new(@:swiftLabel("_") placeholder:String, @:swiftLabel("text") @:swiftBinding textBinding:String) {
+        super();
+        this.viewType = "SecureField";
+        this.placeholder = placeholder;
+        this.textBinding = textBinding;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SecureField` view class mirroring `TextField` API but rendering as SwiftUI's `SecureField` (hidden input)
- Document in views/controls.md and views overview table

Closes #6

## Test plan

- [ ] `new SecureField("Password", "pass")` generates `SecureField("Password", text: $pass)`
- [ ] Supports same `textFieldStyle` modifier as TextField
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)