### PR TITLE
Add onTapGesture modifier with StateAction support

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -119,6 +119,24 @@ new VStack([...])
 |----------|-----------|-------------|
 | `.animation(value)` | `value: String` | Animation curve (e.g. `"default"`, `"easeIn"`, `"spring"`) |
 
+## Gestures
+
+| Modifier | Parameters | Description |
+|----------|-----------|-------------|
+| `.onTapGesture(action)` | `action: StateAction` | Runs a StateAction when tapped |
+
+```haxe
+// Set state on tap
+new Text("Select me")
+    .onTapGesture(StateAction.SetValue("selected", "true"))
+
+// Use with ForEach for interactive lists
+new ForEach("items", "i",
+    new Text("{items[i].name}")
+        .onTapGesture(StateAction.SetValue("selectedItem", "{items[i].id}"))
+)
+```
+
 ## Lifecycle
 
 | Modifier | Parameters | Description |

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -141,6 +141,12 @@ class View {
         return this;
     }
 
+    /** Add a tap gesture with a declarative StateAction. **/
+    public function onTapGesture(action:sui.state.StateAction):View {
+        modifierChain.push(ViewModifier.OnTapGesture(action));
+        return this;
+    }
+
     /** Run a closure when the view appears. Runs in Haxe via the bridge. **/
     public function onAppear(action:() -> Void):View {
         var actionId = sui.ui.Button._nextActionId++;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1343,7 +1343,8 @@ class SwiftGenerator {
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
                  "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
-                 "onAppear" | "onDisappear" | "task" | "navigationDestination":
+                 "onAppear" | "onDisappear" | "task" | "navigationDestination" |
+                 "onTapGesture":
                 true;
             default: false;
         }
@@ -1415,6 +1416,14 @@ class SwiftGenerator {
             case "task":
                 needsRuntimeBridge = true;
                 'task { HaxeBridgeC.invokeAction(__LIFECYCLE_ACTION__) }';
+
+            case "onTapGesture":
+                // Extract the StateAction from the argument
+                var actionCode = if (args.length > 0) stateActionToSwift(args[0]) else null;
+                if (actionCode != null)
+                    'onTapGesture { ${actionCode} }';
+                else
+                    'onTapGesture { }';
 
             // --- Content-bearing modifiers ---
             case "sheet":

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -57,6 +57,9 @@ enum ViewModifier {
     OnDisappear(actionId:Int);
     TaskOnAppear(actionId:Int);
 
+    // Gestures
+    OnTapGesture(action:sui.state.StateAction);
+
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);
 }


### PR DESCRIPTION
## Summary

- Add `onTapGesture(action:StateAction)` modifier to `View`
- Add `OnTapGesture` variant to `ViewModifier` enum
- Register and generate Swift for `onTapGesture` in SwiftGenerator
- Generates `.onTapGesture { stateAction }` in Swift
- Works with ForEach items for interactive lists

Closes #8

## Test plan

- [ ] `.onTapGesture(StateAction.SetValue("x", "1"))` generates `.onTapGesture { x = 1 }`
- [ ] Works on ForEach children
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)