### PR TITLE
Update all docs to @:state syntax

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -1,6 +1,6 @@
 # Bridge
 
-sui includes a **transparent bridge** between Swift and Haxe/C++. Most of the time, you just write normal Haxe code &mdash; closures, `State.set()`, lifecycle handlers &mdash; and the framework handles the bridging automatically. No annotations required.
+sui includes a **transparent bridge** between Swift and Haxe/C++. Most of the time, you just write normal Haxe code &mdash; closures, state updates, lifecycle handlers &mdash; and the framework handles the bridging automatically. No annotations required.
 
 ## Transparent Bridge (Automatic)
 
@@ -12,18 +12,18 @@ Pass any Haxe function or closure to a Button. It runs via the bridge automatica
 
 ```haxe
 new Button("Say Hello", () -> {
-    myState.set("Hello from Haxe! Time: " + Date.now().toString());
+    myState.value = "Hello from Haxe! Time: " + Date.now().toString();
 })
 ```
 
 Under the hood, the framework registers the closure in an action registry and generates Swift code that calls `HaxeBridgeC.invokeAction(id)`. You never see this &mdash; it just works.
 
-### State.set()
+### State Updates
 
-When you call `state.set()` from Haxe, the update flows back to SwiftUI automatically:
+When you update a `@:state` variable from Haxe, the update flows back to SwiftUI automatically:
 
 ```
-Haxe: state.set(newValue)
+Haxe: state.value = newValue
     │
     ▼
 C++ bridge: update stored value, notify Swift callback
@@ -35,7 +35,7 @@ Swift: @State property update
 SwiftUI: automatic re-render
 ```
 
-No annotation needed. Any `State<T>` variable participates in this flow.
+No annotation needed. Any `@:state` variable participates in this flow.
 
 ### Lifecycle Closures
 
@@ -44,15 +44,15 @@ No annotation needed. Any `State<T>` variable participates in this flow.
 ```haxe
 new VStack([...])
     .task(() -> {
-        status.set("Loading...");
+        status.value = "Loading...";
         var http = new haxe.Http("https://example.com");
-        http.onData = (d) -> data.set(d);
+        http.onData = (d) -> data.value = d;
         http.request(false);
     })
     .onDisappear(() -> trace("View disappeared"))
 ```
 
-These closures run in Haxe/C++ and can call `state.set()` to push updates back to SwiftUI.
+These closures run in Haxe/C++ and can update `@:state` variables to push updates back to SwiftUI.
 
 ## @:bridge (Explicit Named Exports)
 
@@ -74,7 +74,7 @@ new Button("Greet", null,
 ```haxe
 // No annotation — just use a closure
 new Button("Greet", () -> {
-    result.set('Hello, World! (from Haxe/C++)');
+    result.value = 'Hello, World! (from Haxe/C++)';
 })
 ```
 
@@ -89,7 +89,7 @@ Use `@:bridge` when you need to:
 
 You do **not** need `@:bridge` for:
 - Button closures (automatic)
-- `State.set()` updates (automatic)
+- `@:state` variable updates (automatic)
 - Lifecycle closures like `onAppear`, `task`, `onDisappear` (automatic)
 
 ## Calling @:bridge Functions
@@ -103,7 +103,7 @@ new Button("Greet", null,
 
 // Without @:bridge — same logic via closure
 new Button("Greet", () -> {
-    result.set('Hello, World! (from Haxe/C++)');
+    result.value = 'Hello, World! (from Haxe/C++)';
 })
 ```
 
@@ -119,7 +119,7 @@ new Button("Login", null,
     StateAction.BridgeCall("result", "doLogin", ["https://api.example.com", "user@email.com", "pass123"]))
 
 // Without @:bridge — same logic via closure
-new Button("Greet", () -> result.set(greet("World")))
+new Button("Greet", () -> result.value = greet("World"))
 ```
 
 ### Async with BridgeCallLoading
@@ -145,7 +145,7 @@ The `BridgeCallLoading` version sets the loading text immediately, then runs the
 │  Transparent (automatic)                        │
 │                                                 │
 │  Button closure ──→ action registry ──→ C++     │
-│  State.set()    ──→ callback        ──→ Swift   │
+│  state.value =  ──→ callback        ──→ Swift   │
 │  onAppear/task  ──→ action registry ──→ C++     │
 ├─────────────────────────────────────────────────┤
 │  @:bridge (explicit)                            │
@@ -161,13 +161,12 @@ The transparent bridge handles closures and state synchronization without any an
 
 ```haxe
 class BridgeApp extends App {
-    var result:State<String>;
+    @:state var result:String = "Press a button!";
 
     public function new() {
         super();
         appName = "BridgeDemo";
         bundleIdentifier = "com.sui.bridgedemo";
-        result = new State<String>("Press a button!", "result");
     }
 
     // Explicit bridge: callable by name from Swift as HaxeBridgeC.greet()
@@ -196,7 +195,7 @@ class BridgeApp extends App {
 
             // Uses transparent bridge (closure, no annotation needed)
             new Button("Hello via closure", () -> {
-                result.set("Hello from a closure!");
+                result.value = "Hello from a closure!";
             }),
         ]);
     }
@@ -205,12 +204,12 @@ class BridgeApp extends App {
 
 ## Multi-State Updates with State.setByName
 
-When a bridge function needs to update multiple state variables, use `State.setByName()` from a closure:
+When a bridge function needs to update multiple `@:state` variables, use `State.setByName()` from a closure:
 
 ```haxe
 new Button("Login", () -> {
     State.setByName("status", "Logging in...");
-    var result = doLogin(email.get(), password.get());
+    var result = doLogin(email.value, password.value);
     State.setByName("userName", result.name);
     State.setByName("mailboxCount", Std.string(result.mailboxes));
     State.setByName("isLoggedIn", "true");
@@ -218,14 +217,14 @@ new Button("Login", () -> {
 })
 ```
 
-Each `setByName` call immediately pushes the value to SwiftUI. This is the same mechanism that `State.set()` uses internally, but lets you target any state variable by name without needing a reference to the `State<T>` instance.
+Each `setByName` call immediately pushes the value to SwiftUI. This is the same mechanism that `.value =` uses internally, but lets you target any state variable by name without needing a direct reference to the `@:state` variable.
 
 ## Key Points
 
-- **Most bridging is automatic** &mdash; closures and `State.set()` just work
+- **Most bridging is automatic** &mdash; closures and `@:state` updates just work
 - `@:bridge` is only needed for named function exports callable from Swift expressions
 - `@:bridge` functions must be `public static`
 - They can accept and return basic types (`String`, `Int`, `Float`, `Bool`)
 - The generated bridge uses `HaxeBridgeC.functionName()` in Swift
 - Use `BridgeCallLoading` for operations that take time
-- Use `State.setByName()` to update multiple states from a single closure
+- Use `State.setByName()` to update multiple `@:state` variables from a single closure

--- a/docs/components.md
+++ b/docs/components.md
@@ -82,7 +82,7 @@ class StarRating extends ViewComponent {
 Pass a state variable name to bind:
 
 ```haxe
-var movieRating:State<Int>;
+@:state var movieRating:Int = 3;
 
 // In body():
 new StarRating("Movie:", "movieRating")

--- a/docs/examples/async-fetch.md
+++ b/docs/examples/async-fetch.md
@@ -14,13 +14,12 @@ import sui.state.StateAction;
 class FetchApp extends App {
     static function main() {}
 
-    var result:State<String>;
+    @:state var result:String = "Press a button to fetch data";
 
     public function new() {
         super();
         appName = "AsyncFetch";
         bundleIdentifier = "com.sui.asyncfetch";
-        result = new State<String>("Press a button to fetch data", "result");
     }
 
     @:bridge
@@ -86,8 +85,8 @@ public static function fetchUrl(url:String):String {
 
 // Call via closure — handle loading state yourself
 new Button("Fetch example.com", () -> {
-    result.set("Loading...");
-    result.set(fetchUrl("https://example.com"));
+    result.value = "Loading...";
+    result.value = fetchUrl("https://example.com");
 })
 ```
 
@@ -107,10 +106,10 @@ This generates Swift code that:
 
 ```haxe
 new Button("Fetch example.com", () -> {
-    result.set("Loading...");
+    result.value = "Loading...";
     var http = new haxe.Http("https://example.com");
-    http.onData = (d) -> result.set(d.length > 500 ? d.substr(0, 500) + "..." : d);
-    http.onError = (e) -> result.set("Error: " + e);
+    http.onData = (d) -> result.value = d.length > 500 ? d.substr(0, 500) + "..." : d;
+    http.onError = (e) -> result.value = "Error: " + e;
     http.request(false);
 })
 ```

--- a/docs/examples/bridge-demo.md
+++ b/docs/examples/bridge-demo.md
@@ -1,6 +1,6 @@
 # Bridge Demo
 
-Demonstrates the explicit `@:bridge` annotation for exposing named Haxe functions to Swift. Note that most bridging (closures, `State.set()`, lifecycle handlers) is automatic and needs no annotation &mdash; `@:bridge` is only for named function exports.
+Demonstrates the explicit `@:bridge` annotation for exposing named Haxe functions to Swift. Note that most bridging (closures, `@:state` updates, lifecycle handlers) is automatic and needs no annotation &mdash; `@:bridge` is only for named function exports.
 
 ## Full Source
 
@@ -14,13 +14,12 @@ import sui.state.StateAction;
 class BridgeApp extends App {
     static function main() {}
 
-    var result:State<String>;
+    @:state var result:String = "Press a button!";
 
     public function new() {
         super();
         appName = "BridgeDemo";
         bundleIdentifier = "com.sui.bridgedemo";
-        result = new State<String>("Press a button!", "result");
     }
 
     @:bridge
@@ -72,7 +71,7 @@ public static function greet(name:String):String {
 }
 
 new Button("Greet from Haxe", () -> {
-    result.set(greet("World"));
+    result.value = greet("World");
 })
 ```
 
@@ -88,7 +87,7 @@ new Button("Greet from Haxe", null,
 **Without @:bridge** &mdash; use a closure instead:
 
 ```haxe
-new Button("Greet from Haxe", () -> result.set(greet("World")))
+new Button("Greet from Haxe", () -> result.value = greet("World"))
 ```
 
 Both produce the same result. The `@:bridge` version is useful when you need the return value in a `CustomSwift` expression or want to compose calls in Swift code.
@@ -108,7 +107,7 @@ new Button("Fibonacci(20)", null,
 
 // Without @:bridge:
 new Button("Fibonacci(20)", () -> {
-    result.set("fib(20) = " + fibonacci(20));
+    result.value = "fib(20) = " + fibonacci(20);
 })
 ```
 

--- a/docs/examples/counter.md
+++ b/docs/examples/counter.md
@@ -1,6 +1,6 @@
 # Counter
 
-A counter app demonstrating state management with `State<T>`, `StateAction`, and `Text.withState`.
+A counter app demonstrating state management with `@:state`, `StateAction`, and `Text.withState`.
 
 ## Full Source
 
@@ -14,13 +14,12 @@ import sui.state.StateAction;
 class CounterApp extends App {
     static function main() {}
 
-    var count:State<Int>;
+    @:state var count:Int = 0;
 
     public function new() {
         super();
         appName = "Counter";
         bundleIdentifier = "com.sui.counter";
-        count = new State<Int>(0, "count");
     }
 
     override function body():View {
@@ -29,9 +28,9 @@ class CounterApp extends App {
                 .font(FontStyle.Title)
                 .padding(),
             new HStack(null, 20, [
-                new Button("-", () -> count.set(count.get() - 1),
+                new Button("-", () -> count.value = count.value - 1,
                     StateAction.Decrement("count", 1)),
-                new Button("+", () -> count.set(count.get() + 1),
+                new Button("+", () -> count.value = count.value + 1,
                     StateAction.Increment("count", 1))
             ])
         ]);
@@ -44,13 +43,10 @@ class CounterApp extends App {
 ### Declaring State
 
 ```haxe
-var count:State<Int>;
-
-// In constructor:
-count = new State<Int>(0, "count");
+@:state var count:Int = 0;
 ```
 
-`State<Int>` creates a reactive integer. The second argument `"count"` is the name used in generated Swift (`@State var count: Int = 0`).
+`@:state` creates a reactive integer. The variable name is used in generated Swift (`@State var count: Int = 0`). No constructor initialization needed.
 
 ### Displaying State
 
@@ -63,13 +59,13 @@ Text.withState("Count: {count}")
 ### Mutating State
 
 ```haxe
-new Button("-", () -> count.set(count.get() - 1),
+new Button("-", () -> count.value = count.value - 1,
     StateAction.Decrement("count", 1))
 ```
 
 Each button has two actions:
 
-1. **Haxe closure** `() -> count.set(count.get() - 1)` &mdash; Runs on the Haxe/C++ side, bridged automatically (no `@:bridge` needed)
+1. **Haxe closure** `() -> count.value = count.value - 1` &mdash; Runs on the Haxe/C++ side, bridged automatically (no `@:bridge` needed)
 2. **StateAction** `StateAction.Decrement("count", 1)` &mdash; Generates Swift `count -= 1` for immediate UI update
 
 Both are optional. Use `StateAction` for instant SwiftUI updates, closures for Haxe-side logic.

--- a/docs/examples/todo-app.md
+++ b/docs/examples/todo-app.md
@@ -26,15 +26,13 @@ class TodoItem extends Observable {
 class TodoApp extends App {
     static function main() {}
 
-    var todos:State<Array<TodoItem>>;
-    var newItemText:State<String>;
+    @:state var todos:Array<TodoItem> = [];
+    @:state var newItemText:String = "";
 
     public function new() {
         super();
         appName = "TodoList";
         bundleIdentifier = "com.sui.todoapp";
-        todos = new State<Array<TodoItem>>([], "todos");
-        newItemText = new State<String>("", "newItemText");
     }
 
     override function body():View {
@@ -81,11 +79,10 @@ class TodoItem extends Observable {
 ### State Arrays
 
 ```haxe
-var todos:State<Array<TodoItem>>;
-todos = new State<Array<TodoItem>>([], "todos");
+@:state var todos:Array<TodoItem> = [];
 ```
 
-State can hold arrays of Observable objects. SwiftUI renders the list and updates when items are added, removed, or modified.
+`@:state` can hold arrays of Observable objects. SwiftUI renders the list and updates when items are added, removed, or modified.
 
 ### Text Input + Add Button
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -6,7 +6,7 @@ sui uses Haxe metadata annotations to control Swift code generation.
 
 Exposes a named static function to Swift via the C++ bridge. This is only needed when you want to call a specific function by name from Swift expressions (e.g., in `StateAction.CustomSwift`, `BridgeCall`, or `BridgeCallLoading`).
 
-Most bridge interactions are **automatic** &mdash; button closures, `State.set()`, and lifecycle handlers work without any annotation.
+Most bridge interactions are **automatic** &mdash; button closures, `@:state` updates, and lifecycle handlers work without any annotation.
 
 **With @:bridge:**
 ```haxe
@@ -27,7 +27,7 @@ public static function greet(name:String):String {
 }
 
 // Call via closure — bridged automatically:
-new Button("Greet", () -> result.set(greet("World")))
+new Button("Greet", () -> result.value = greet("World"))
 ```
 
 **Generated Swift (with @:bridge):** `HaxeBridgeC.greet("World")`

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -154,9 +154,9 @@ new VStack([...])
     .onDisappear(() -> trace("View disappeared"))
     .task(() -> {
         // Runs when view appears, good for loading data
-        myState.set("Loading...");
+        myState.value = "Loading...";
         var http = new haxe.Http("https://example.com");
-        http.onData = (d) -> myState.set(d);
+        http.onData = (d) -> myState.value = d;
         http.request(false);
     })
 ```

--- a/docs/state/binding.md
+++ b/docs/state/binding.md
@@ -6,7 +6,7 @@ Bindings provide a two-way connection to a state variable. They're how child com
 
 | Haxe | SwiftUI |
 |------|---------|
-| `State<T>` in parent | `@State var value: T` |
+| `@:state var value:T` in parent | `@State var value: T` |
 | `@:swiftBinding` in component | `@Binding var value: T` |
 
 ## Using Bindings with ViewComponent
@@ -41,11 +41,10 @@ Use it in a parent app:
 
 ```haxe
 class MyApp extends App {
-    var movieRating:State<Int>;
+    @:state var movieRating:Int = 3;
 
     public function new() {
         super();
-        movieRating = new State<Int>(3, "movieRating");
     }
 
     override function body():View {
@@ -69,8 +68,8 @@ var binding = Binding.fromState(myState);
 
 // Create with custom getter/setter
 var binding = new Binding<String>(
-    () -> myState.get(),
-    (v) -> myState.set(v)
+    () -> myState.value,
+    (v) -> myState.value = v
 );
 ```
 
@@ -78,7 +77,7 @@ var binding = new Binding<String>(
 
 | Method | Description |
 |--------|-------------|
-| `Binding.fromState(state)` | Create a binding from a `State<T>` |
+| `Binding.fromState(state)` | Create a binding from a `@:state` variable |
 | `.value` | Read/write the bound value |
 
 ## Built-in Binding Parameters

--- a/docs/state/observable.md
+++ b/docs/state/observable.md
@@ -31,15 +31,14 @@ struct TodoItem: Identifiable, Hashable {
 
 ## Using with State
 
-Observable objects are stored in `State` arrays. SwiftUI re-renders automatically when the array or its elements change:
+Observable objects are stored in `@:state` arrays. SwiftUI re-renders automatically when the array or its elements change:
 
 ```haxe
 class TodoApp extends App {
-    var todos:State<Array<TodoItem>>;
+    @:state var todos:Array<TodoItem> = [];
 
     public function new() {
         super();
-        todos = new State<Array<TodoItem>>([], "todos");
     }
 
     override function body():View {
@@ -61,7 +60,7 @@ Mutating `todos[i].completed` directly in Swift triggers a re-render because the
 
 ## Key Points
 
-- Extend `Observable` for any data model used in `@State` arrays
+- Extend `Observable` for any data model used in `@:state` arrays
 - Public properties become Swift struct fields automatically
 - Reactivity comes from `@State` on the array &mdash; no manual change tracking required
 - Use `Text.withState("{array[index].property}")` to display properties

--- a/docs/state/state-and-actions.md
+++ b/docs/state/state-and-actions.md
@@ -1,58 +1,46 @@
 # State & Actions
 
-## State\<T\>
+## @:state
 
-`State<T>` declares a reactive state variable. It generates a `@State var` in Swift.
+`@:state` declares a reactive state variable. It generates a `@State var` in Swift.
 
 ```haxe
-var count:State<Int>;
-var name:State<String>;
-var items:State<Array<TodoItem>>;
-
-public function new() {
-    super();
-    count = new State<Int>(0, "count");
-    name = new State<String>("", "name");
-    items = new State<Array<TodoItem>>([], "items");
-}
+@:state var count:Int = 0;
+@:state var name:String = "";
+@:state var items:Array<TodoItem> = [];
 ```
+
+No constructor initialization needed &mdash; the default value is specified inline.
 
 ### Supported Types
 
-`State<T>` validates the type parameter at compile time. Only the following types are allowed:
+`@:state` validates the type at compile time. Only the following types are allowed:
 
 | Type | Example | Valid? |
 |------|---------|--------|
-| `Int` | `State<Int>` | Yes |
-| `Float` | `State<Float>` | Yes |
-| `Bool` | `State<Bool>` | Yes |
-| `String` | `State<String>` | Yes |
-| `Array<BasicType>` | `State<Array<String>>` | Yes |
-| `Array<Observable>` | `State<Array<TodoItem>>` | Yes, if `TodoItem` extends `Observable` |
-| Other classes | `State<MyClass>` | Only if `MyClass` extends `Observable` |
+| `Int` | `@:state var x:Int = 0` | Yes |
+| `Float` | `@:state var x:Float = 0.0` | Yes |
+| `Bool` | `@:state var x:Bool = false` | Yes |
+| `String` | `@:state var x:String = ""` | Yes |
+| `Array<BasicType>` | `@:state var x:Array<String> = []` | Yes |
+| `Array<Observable>` | `@:state var x:Array<TodoItem> = []` | Yes, if `TodoItem` extends `Observable` |
+| Other classes | `@:state var x:MyClass` | Only if `MyClass` extends `Observable` |
 
-Using an unsupported type (e.g. `State<Array<SomeClass>>` where `SomeClass` doesn't extend `Observable`) produces a compile-time error:
+Using an unsupported type (e.g. `@:state var x:Array<SomeClass>` where `SomeClass` doesn't extend `Observable`) produces a compile-time error:
 
 ```
-[SwiftGen] State<SomeClass> is not supported. Use a basic type (Int, Float, Bool, String),
+[SwiftGen] State type SomeClass is not supported. Use a basic type (Int, Float, Bool, String),
 an array of basic types, or a class extending Observable.
 ```
 
-**Constructor:**
+**Access:**
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `initialValue` | `T` | Starting value |
-| `name` | `String` | Variable name in generated Swift |
-
-**Methods:**
-
-| Method | Description |
+| Syntax | Description |
 |--------|-------------|
-| `.get()` | Read the current value (Haxe side) |
-| `.set(newValue)` | Update the value and notify SwiftUI |
+| `.value` | Read the current value (Haxe side) |
+| `.value = newValue` | Update the value and notify SwiftUI |
 
-The `name` parameter is critical &mdash; it must match what you use in `StateAction`, `Text.withState`, and binding references.
+The variable name is used directly in `StateAction`, `Text.withState`, and binding references.
 
 ## StateAction
 
@@ -115,13 +103,12 @@ Text.withState("{todos[i].title}")      // → Text("\(todos[i].title)")
 
 ```haxe
 class CounterApp extends App {
-    var count:State<Int>;
+    @:state var count:Int = 0;
 
     public function new() {
         super();
         appName = "Counter";
         bundleIdentifier = "com.example.counter";
-        count = new State<Int>(0, "count");
     }
 
     override function body():View {
@@ -130,9 +117,9 @@ class CounterApp extends App {
                 .font(FontStyle.Title)
                 .padding(),
             new HStack(null, 20, [
-                new Button("-", () -> count.set(count.get() - 1),
+                new Button("-", () -> count.value = count.value - 1,
                     StateAction.Decrement("count", 1)),
-                new Button("+", () -> count.set(count.get() + 1),
+                new Button("+", () -> count.value = count.value + 1,
                     StateAction.Increment("count", 1))
             ])
         ]);

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -9,10 +9,10 @@ Triggers an action when tapped.
 new Button("Increment", null, StateAction.Increment("count", 1))
 
 // With a Haxe closure (bridged automatically, no annotation needed)
-new Button("Say Hello", () -> myState.set("Hello!"))
+new Button("Say Hello", () -> myState.value = "Hello!")
 
 // With both (StateAction for Swift, closure for Haxe-side effects)
-new Button("+", () -> count.set(count.get() + 1), StateAction.Increment("count", 1))
+new Button("+", () -> count.value = count.value + 1, StateAction.Increment("count", 1))
 ```
 
 **Parameters:**


### PR DESCRIPTION
## Summary

Update all documentation to use the new idiomatic `@:state` syntax from PR #26. 12 files updated — replaces `var x:State<T>` / `new State<T>()` / `.set()` / `.get()` with `@:state var x:T` / `.value = x` / `.value` throughout.

Old explicit syntax remains documented as an alternative in state/README.md.

## Test plan

- [ ] CI passes
- [ ] No remaining `new State<` in docs (except state/README.md alternative section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)