### PR TITLE
Option 1: Complex types via JSON serialization

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -308,11 +308,19 @@ class SwiftGenerator {
         buf.add("\n    func set(_ key: String, _ value: String) {\n");
         buf.add("        switch key {\n");
         for (sd in stateDecls) {
-            switch (sd.swiftType) {
-                case "Int": buf.add('        case "${sd.name}": ${sd.name} = Int(value) ?? 0\n');
-                case "Double": buf.add('        case "${sd.name}": ${sd.name} = Double(value) ?? 0.0\n');
-                case "Bool": buf.add('        case "${sd.name}": ${sd.name} = value == "true"\n');
-                default: buf.add('        case "${sd.name}": ${sd.name} = value\n');
+            if (sd.swiftType.startsWith("[") && sd.swiftType.endsWith("]")) {
+                buf.add('        case "${sd.name}":\n');
+                buf.add('            if let data = value.data(using: .utf8),\n');
+                buf.add('               let arr = try? JSONSerialization.jsonObject(with: data) as? ${sd.swiftType} {\n');
+                buf.add('                ${sd.name} = arr\n');
+                buf.add('            }\n');
+            } else {
+                switch (sd.swiftType) {
+                    case "Int": buf.add('        case "${sd.name}": ${sd.name} = Int(value) ?? 0\n');
+                    case "Double": buf.add('        case "${sd.name}": ${sd.name} = Double(value) ?? 0.0\n');
+                    case "Bool": buf.add('        case "${sd.name}": ${sd.name} = value == "true"\n');
+                    default: buf.add('        case "${sd.name}": ${sd.name} = value\n');
+                }
             }
         }
         buf.add("        default: break\n");

--- a/src/sui/state/State.hx
+++ b/src/sui/state/State.hx
@@ -62,7 +62,12 @@ class State<T> {
         }
         #if cpp
         var k = name;
-        var v = Std.string(newValue);
+        var v:String;
+        if (Std.isOfType(newValue, Array)) {
+            v = haxe.Json.stringify(newValue);
+        } else {
+            v = Std.string(newValue);
+        }
         untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', k, v);
         #end
         return newValue;


### PR DESCRIPTION
## Approach

Serialize arrays to JSON on the Haxe side, parse with `JSONSerialization` on the Swift side.

**+19 lines changed across 2 files.**

### Haxe side (`State.hx`)
- `set_value` checks `Std.isOfType(newValue, Array)` at runtime
- If array: `haxe.Json.stringify(newValue)` instead of `Std.string(newValue)`
- Basic types unchanged

### Swift side (`SwiftGenerator.hx` → `AppState.set()`)
- Array types generate `JSONSerialization.jsonObject(with:)` parsing
- Casts to correct Swift array type (`[String]`, `[Int]`, etc.)
- Non-array types unchanged

### Tradeoffs
- **Pro**: Simple, minimal code change, uses existing bridge signature
- **Pro**: No new C functions or memory management
- **Con**: Serialization/deserialization overhead (negligible for UI state)
- **Con**: Nested objects need Codable support (not implemented yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)