### PR TITLE
Add cover page to docs

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,0 +1,14 @@
+# sui
+
+> Build native Apple apps in Haxe.
+
+Write SwiftUI applications entirely in Haxe. Your code compiles to C++ via hxcpp, bridges into Swift, and produces genuine native apps for macOS, iOS, iPadOS, and visionOS.
+
+- Reactive state with `@:state`
+- 25+ SwiftUI views and 30+ modifiers
+- Transparent Haxe/C++ bridge
+- Shared-memory data access
+- SPM packages and native Swift extensions
+
+[GitHub](https://github.com/Pign/sui)
+[Get Started](getting-started.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,6 +30,7 @@
     window.$docsify = {
       name: 'sui',
       repo: 'https://github.com/Pign/sui',
+      coverpage: true,
       loadSidebar: true,
       subMaxLevel: 3,
       search: {


### PR DESCRIPTION
## Summary

- Add Docsify cover page (`_coverpage.md`) with tagline, feature highlights, and CTA buttons
- Enable `coverpage: true` in docsify config

🤖 Generated with [Claude Code](https://claude.com/claude-code)