### PR TITLE
Fix ConditionalView state replacement in AppState mode

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -215,6 +215,9 @@ class SwiftGenerator {
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "{" + n + "}", '\\(' + placeholder + n + ')');
                 // Replace bare "name = " (assignment in closures) with __APPSTATE__name =
                 bodyWithAppState = StringTools.replace(bodyWithAppState, n + " = ", placeholder + n + " = ");
+                // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");


### PR DESCRIPTION
## Summary

Fix `if stateName {` not getting rewritten to `if appState.stateName {` in bridge/AppState mode. Without this, ConditionalView boolean conditions fail to compile in Swift.

## Test plan

- [ ] CI passes
- [ ] `ConditionalView("isLoggedIn", ...)` generates `if appState.isLoggedIn {` in bridge mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)