### PR TITLE
Add ViewNode bridge + DynamicView for CPPIA hot reload

### DIFF
--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+/// Recursively renders a Haxe view tree at runtime.
+/// Used by `mui watch` for hot reload — the Swift host stays running
+/// while the .cppia script is reloaded with new view code.
+///
+/// Each ViewNode maps to its SwiftUI equivalent via a switch on viewType.
+/// Modifiers are applied dynamically from the modifier chain.
+
+// MARK: - ViewNode wrapper
+
+/// Opaque wrapper around a Haxe View pointer from the bridge.
+struct ViewNode: Identifiable {
+    let pointer: UnsafeMutableRawPointer?
+    let id = UUID()
+
+    var viewType: String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_get_type(ptr))
+    }
+
+    var childCount: Int {
+        guard let ptr = pointer else { return 0 }
+        return Int(viewnode_child_count(ptr))
+    }
+
+    func child(at index: Int) -> ViewNode {
+        guard let ptr = pointer else { return ViewNode(pointer: nil) }
+        return ViewNode(pointer: viewnode_get_child(ptr, Int32(index)))
+    }
+
+    var children: [ViewNode] {
+        (0..<childCount).map { child(at: $0) }
+    }
+
+    var textContent: String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_get_text(ptr))
+    }
+
+    var buttonLabel: String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_get_button_label(ptr))
+    }
+
+    var buttonActionId: Int32 {
+        guard let ptr = pointer else { return -1 }
+        return viewnode_get_button_action_id(ptr)
+    }
+
+    func property(_ key: String) -> String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_get_property(ptr, key))
+    }
+
+    var modifierCount: Int {
+        guard let ptr = pointer else { return 0 }
+        return Int(viewnode_modifier_count(ptr))
+    }
+
+    func modifierType(at index: Int) -> String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_modifier_type(ptr, Int32(index)))
+    }
+
+    func modifierFloat(at index: Int, param: Int = 0) -> Double {
+        guard let ptr = pointer else { return 0 }
+        return viewnode_modifier_float(ptr, Int32(index), Int32(param))
+    }
+}
+
+// MARK: - Dynamic SwiftUI Renderer
+
+/// Renders a ViewNode as a SwiftUI view, recursively processing children.
+struct DynamicView: View {
+    let node: ViewNode
+
+    var body: some View {
+        applyModifiers(to: renderContent())
+    }
+
+    @ViewBuilder
+    private func renderContent() -> some View {
+        switch node.viewType {
+        case "VStack":
+            VStack(spacing: spacingFromProperties()) {
+                ForEach(node.children) { child in
+                    DynamicView(node: child)
+                }
+            }
+
+        case "HStack":
+            HStack(spacing: spacingFromProperties()) {
+                ForEach(node.children) { child in
+                    DynamicView(node: child)
+                }
+            }
+
+        case "ZStack":
+            ZStack {
+                ForEach(node.children) { child in
+                    DynamicView(node: child)
+                }
+            }
+
+        case "Text":
+            Text(node.textContent)
+
+        case "Button":
+            let actionId = node.buttonActionId
+            Button(node.buttonLabel) {
+                if actionId >= 0 {
+                    haxe_bridge_invoke_action(actionId)
+                }
+            }
+
+        case "Spacer":
+            Spacer()
+
+        case "Divider":
+            Divider()
+
+        case "Toggle":
+            // Toggle requires state binding — simplified for now
+            Text("[Toggle: \(node.property("label"))]")
+
+        case "TextField":
+            // TextField requires state binding — simplified for now
+            Text("[TextField: \(node.property("placeholder"))]")
+
+        case "Image":
+            let name = node.property("systemName")
+            if !name.isEmpty {
+                Image(systemName: name)
+            } else {
+                Image(node.property("name"))
+            }
+
+        case "ProgressView":
+            ProgressView()
+
+        case "ScrollView":
+            ScrollView {
+                VStack {
+                    ForEach(node.children) { child in
+                        DynamicView(node: child)
+                    }
+                }
+            }
+
+        default:
+            // Unknown view type — render children if any
+            if node.childCount > 0 {
+                VStack {
+                    ForEach(node.children) { child in
+                        DynamicView(node: child)
+                    }
+                }
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
+    // MARK: - Modifier application
+
+    private func applyModifiers<V: View>(to view: V) -> AnyView {
+        var result: AnyView = AnyView(view)
+
+        for i in 0..<node.modifierCount {
+            let modType = node.modifierType(at: i)
+
+            switch modType {
+            case "Padding":
+                let value = node.modifierFloat(at: i)
+                result = AnyView(result.padding(value > 0 ? CGFloat(value) : nil))
+
+            case "PaddingDefault":
+                result = AnyView(result.padding())
+
+            case "Font":
+                let styleStr = node.modifierType(at: i)
+                // Simplified — map common font styles
+                result = AnyView(result.font(.body))
+
+            case "Bold":
+                result = AnyView(result.bold())
+
+            case "Italic":
+                result = AnyView(result.italic())
+
+            case "ForegroundColor":
+                // Would need color enum mapping from bridge
+                break
+
+            case "Background":
+                break
+
+            case "Opacity":
+                let value = node.modifierFloat(at: i)
+                result = AnyView(result.opacity(value))
+
+            case "CornerRadius":
+                let value = node.modifierFloat(at: i)
+                result = AnyView(result.cornerRadius(CGFloat(value)))
+
+            case "Disabled":
+                result = AnyView(result.disabled(true))
+
+            case "NavigationTitle":
+                // Would need string param from bridge
+                break
+
+            default:
+                break
+            }
+        }
+
+        return result
+    }
+
+    private func spacingFromProperties() -> CGFloat? {
+        let spacing = node.property("spacing")
+        if let val = Double(spacing), val > 0 {
+            return CGFloat(val)
+        }
+        return nil
+    }
+}
+
+// MARK: - Hot Reload Root View
+
+/// The root view used in hot reload mode.
+/// Watches for .cppia file changes and triggers re-render.
+struct HotReloadRootView: View {
+    @State private var reloadCount = 0
+
+    var body: some View {
+        let root = ViewNode(pointer: viewnode_get_root())
+        DynamicView(node: root)
+            .id(reloadCount) // force re-render on reload
+            .onReceive(NotificationCenter.default.publisher(for: .viewTreeDidReload)) { _ in
+                reloadCount += 1
+            }
+    }
+}
+
+extension Notification.Name {
+    static let viewTreeDidReload = Notification.Name("viewTreeDidReload")
+}

--- a/runtime/ViewNodeBridge.hx
+++ b/runtime/ViewNodeBridge.hx
@@ -1,0 +1,162 @@
+package sui.runtime;
+
+import sui.View;
+import sui.modifiers.ViewModifier;
+
+/**
+    Runtime view tree bridge for dynamic renderers.
+
+    Exposes the Haxe view tree via C functions so native renderers
+    (SwiftUI DynamicView, Compose DynamicComposable, etc.) can
+    traverse and render it without compile-time codegen.
+
+    Used by `mui watch` for hot reload — the native host stays running
+    while the .cppia script is reloaded with new view code.
+**/
+class ViewNodeBridge {
+    /** The root view tree, rebuilt on each reload. **/
+    static var _root:View = null;
+
+    /** Current app instance. **/
+    static var _app:Dynamic = null;
+
+    /** Set the app instance and build the initial view tree. **/
+    public static function setApp(app:Dynamic):Void {
+        _app = app;
+        rebuild();
+    }
+
+    /** Rebuild the view tree by calling body() on the app. **/
+    public static function rebuild():Void {
+        if (_app != null) {
+            _root = _app.body();
+        }
+    }
+
+    /** Get the root view node. Returns an opaque pointer. **/
+    public static function getRoot():View {
+        return _root;
+    }
+
+    // --- View node accessors (called from C bridge) ---
+
+    /** Get the viewType string (e.g., "VStack", "Text", "Button"). **/
+    public static function getViewType(node:View):String {
+        if (node == null) return "";
+        // Strip package prefix: "sui.ui.VStack" → "VStack"
+        var vt = node.viewType;
+        if (vt == null) return "";
+        var dot = vt.lastIndexOf(".");
+        return dot >= 0 ? vt.substr(dot + 1) : vt;
+    }
+
+    /** Get the number of children. **/
+    public static function getChildCount(node:View):Int {
+        if (node == null || node.children == null) return 0;
+        return node.children.length;
+    }
+
+    /** Get a child by index. **/
+    public static function getChild(node:View, index:Int):View {
+        if (node == null || node.children == null || index < 0 || index >= node.children.length) return null;
+        return node.children[index];
+    }
+
+    /** Get a string property (e.g., "label", "content", "placeholder"). **/
+    public static function getStringProperty(node:View, key:String):String {
+        if (node == null || node.properties == null) return "";
+        var val:Dynamic = node.properties.get(key);
+        return val != null ? Std.string(val) : "";
+    }
+
+    /** Get an int property. **/
+    public static function getIntProperty(node:View, key:String):Int {
+        if (node == null || node.properties == null) return 0;
+        var val:Dynamic = node.properties.get(key);
+        return val != null ? cast(val, Int) : 0;
+    }
+
+    /** Get a float property. **/
+    public static function getFloatProperty(node:View, key:String):Float {
+        if (node == null || node.properties == null) return 0.0;
+        var val:Dynamic = node.properties.get(key);
+        return val != null ? cast(val, Float) : 0.0;
+    }
+
+    /** Get a bool property. **/
+    public static function getBoolProperty(node:View, key:String):Bool {
+        if (node == null || node.properties == null) return false;
+        var val:Dynamic = node.properties.get(key);
+        return val != null ? cast(val, Bool) : false;
+    }
+
+    /** Check if a property exists. **/
+    public static function hasProperty(node:View, key:String):Bool {
+        if (node == null || node.properties == null) return false;
+        return node.properties.exists(key);
+    }
+
+    /** Get the number of modifiers. **/
+    public static function getModifierCount(node:View):Int {
+        if (node == null || node.modifierChain == null) return 0;
+        return node.modifierChain.length;
+    }
+
+    /** Get modifier type name at index. **/
+    public static function getModifierType(node:View, index:Int):String {
+        if (node == null || node.modifierChain == null || index < 0 || index >= node.modifierChain.length) return "";
+        return Type.enumConstructor(node.modifierChain[index]);
+    }
+
+    /** Get modifier float parameter (e.g., padding value, opacity). **/
+    public static function getModifierFloat(node:View, index:Int, paramIndex:Int):Float {
+        if (node == null || node.modifierChain == null || index < 0 || index >= node.modifierChain.length) return 0.0;
+        var params = Type.enumParameters(node.modifierChain[index]);
+        if (paramIndex < 0 || paramIndex >= params.length) return 0.0;
+        var val:Dynamic = params[paramIndex];
+        if (Std.isOfType(val, Float)) return val;
+        if (Std.isOfType(val, Int)) return cast(val, Int) * 1.0;
+        return 0.0;
+    }
+
+    /** Get modifier string parameter (e.g., color name, font style). **/
+    public static function getModifierString(node:View, index:Int, paramIndex:Int):String {
+        if (node == null || node.modifierChain == null || index < 0 || index >= node.modifierChain.length) return "";
+        var params = Type.enumParameters(node.modifierChain[index]);
+        if (paramIndex < 0 || paramIndex >= params.length) return "";
+        return Std.string(params[paramIndex]);
+    }
+
+    // --- Text special accessors ---
+
+    /** Get the text content (for Text views). **/
+    public static function getTextContent(node:View):String {
+        if (node == null) return "";
+        var content:Dynamic = Reflect.field(node, "content");
+        return content != null ? Std.string(content) : "";
+    }
+
+    /** Get the swift expression for state-interpolated text. **/
+    public static function getTextExpression(node:View):String {
+        if (node == null) return "";
+        var expr:Dynamic = Reflect.field(node, "swiftExpression");
+        if (expr == null) expr = Reflect.field(node, "composeExpression");
+        return expr != null ? Std.string(expr) : "";
+    }
+
+    // --- Button special accessors ---
+
+    /** Get button label. **/
+    public static function getButtonLabel(node:View):String {
+        if (node == null) return "";
+        var label:Dynamic = Reflect.field(node, "label");
+        return label != null ? Std.string(label) : "";
+    }
+
+    /** Get button action ID (for invoking via bridge). **/
+    public static function getButtonActionId(node:View):Int {
+        if (node == null) return -1;
+        var id:Dynamic = Reflect.field(node, "actionId");
+        return id != null ? cast(id, Int) : -1;
+    }
+}

--- a/runtime/ViewNodeBridgeC.cpp
+++ b/runtime/ViewNodeBridgeC.cpp
@@ -1,0 +1,244 @@
+/**
+ * C bridge for ViewNode tree traversal.
+ * Called by native dynamic renderers (SwiftUI, Compose, WinUI)
+ * to walk the Haxe view tree at runtime.
+ *
+ * Each function calls into Haxe via hxcpp reflection.
+ */
+
+#include <hxcpp.h>
+
+// Forward declare the Haxe ViewNodeBridge class
+// These will be resolved at link time from the hxcpp static library.
+
+extern "C" {
+
+// --- View tree lifecycle ---
+
+// Rebuild the view tree (call App.body())
+void viewnode_rebuild(void) {
+    hx::SetTopOfStack(nullptr, true);
+    try {
+        ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("rebuild"),
+            ::cpp::ObjectArray<Dynamic>(0, 0)
+        );
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+}
+
+// --- Node accessors (node passed as opaque hxcpp Dynamic) ---
+
+// Get view type string. Caller must copy the result.
+const char* viewnode_get_type(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    const char* result = "";
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getViewType"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<String>().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get number of children
+int32_t viewnode_child_count(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    int32_t result = 0;
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getChildCount"),
+            args
+        );
+        result = (int)ret;
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get child at index (returns opaque pointer)
+void* viewnode_get_child(void* node, int32_t index) {
+    hx::SetTopOfStack(nullptr, true);
+    void* result = nullptr;
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
+        args[0] = hxNode;
+        args[1] = (int)index;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getChild"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<hx::Object*>();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get text content
+const char* viewnode_get_text(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    const char* result = "";
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getTextContent"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<String>().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get button label
+const char* viewnode_get_button_label(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    const char* result = "";
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getButtonLabel"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<String>().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get button action ID
+int32_t viewnode_get_button_action_id(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    int32_t result = -1;
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getButtonActionId"),
+            args
+        );
+        result = (int)ret;
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get string property
+const char* viewnode_get_property(void* node, const char* key) {
+    hx::SetTopOfStack(nullptr, true);
+    const char* result = "";
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
+        args[0] = hxNode;
+        args[1] = ::String(key);
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getStringProperty"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<String>().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get modifier count
+int32_t viewnode_modifier_count(void* node) {
+    hx::SetTopOfStack(nullptr, true);
+    int32_t result = 0;
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
+        args[0] = hxNode;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getModifierCount"),
+            args
+        );
+        result = (int)ret;
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get modifier type name at index
+const char* viewnode_modifier_type(void* node, int32_t index) {
+    hx::SetTopOfStack(nullptr, true);
+    const char* result = "";
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
+        args[0] = hxNode;
+        args[1] = (int)index;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getModifierType"),
+            args
+        );
+        if (ret != null()) result = ret.val_cast<String>().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get modifier float parameter
+double viewnode_modifier_float(void* node, int32_t index, int32_t paramIndex) {
+    hx::SetTopOfStack(nullptr, true);
+    double result = 0.0;
+    try {
+        Dynamic hxNode = (hx::Object*)node;
+        auto args = ::cpp::ObjectArray<Dynamic>(3, 3);
+        args[0] = hxNode;
+        args[1] = (int)index;
+        args[2] = (int)paramIndex;
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getModifierFloat"),
+            args
+        );
+        result = (double)ret;
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+// Get root view node (returns opaque pointer)
+void* viewnode_get_root(void) {
+    hx::SetTopOfStack(nullptr, true);
+    void* result = nullptr;
+    try {
+        Dynamic ret = ::Type_obj::callStatic(
+            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
+            HX_CSTRING("getRoot"),
+            ::cpp::ObjectArray<Dynamic>(0, 0)
+        );
+        if (ret != null()) result = ret.val_cast<hx::Object*>();
+    } catch (...) {}
+    hx::SetTopOfStack(nullptr, false);
+    return result;
+}
+
+} // extern "C"

--- a/runtime/ViewNodeBridgeC.h
+++ b/runtime/ViewNodeBridgeC.h
@@ -1,0 +1,38 @@
+#ifndef VIEWNODE_BRIDGE_H
+#define VIEWNODE_BRIDGE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// --- View tree lifecycle ---
+void viewnode_rebuild(void);
+void* viewnode_get_root(void);
+
+// --- Node accessors ---
+const char* viewnode_get_type(void* node);
+int32_t viewnode_child_count(void* node);
+void* viewnode_get_child(void* node, int32_t index);
+
+// --- Properties ---
+const char* viewnode_get_property(void* node, const char* key);
+
+// --- Text ---
+const char* viewnode_get_text(void* node);
+
+// --- Button ---
+const char* viewnode_get_button_label(void* node);
+int32_t viewnode_get_button_action_id(void* node);
+
+// --- Modifiers ---
+int32_t viewnode_modifier_count(void* node);
+const char* viewnode_modifier_type(void* node, int32_t index);
+double viewnode_modifier_float(void* node, int32_t index, int32_t paramIndex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VIEWNODE_BRIDGE_H


### PR DESCRIPTION
## Summary

Foundation for CPPIA-based hot reload in sui. Two main pieces:

**ViewNode bridge protocol** (reusable across backends):
- `ViewNodeBridge.hx`: Haxe-side accessors for traversing the view tree at runtime
- `ViewNodeBridgeC.cpp/h`: C bridge functions (`viewnode_get_type`, `viewnode_child_count`, `viewnode_get_child`, etc.)
- Designed to be shared by sui/aui/wui dynamic renderers

**DynamicView.swift** (SwiftUI dynamic renderer):
- Recursive `DynamicView` component that renders ViewNodes via `@ViewBuilder` + `AnyView`
- Handles: VStack, HStack, ZStack, Text, Button, Spacer, Divider, Image, ProgressView, ScrollView
- Applies modifiers dynamically (padding, bold, italic, opacity, cornerRadius, disabled)
- `HotReloadRootView` with Notification-based re-render on .cppia reload

**Architecture:**
```
SwiftUI Host (stays running)
  └─ HotReloadRootView
       └─ DynamicView (recursive)
            └─ reads ViewNodes via C bridge
                 └─ CPPIA VM (reloads .cppia script in <1s)
```

## Test plan
- [ ] ViewNode bridge compiles with hxcpp
- [ ] DynamicView renders a counter app view tree
- [ ] Hot reload: change body(), recompile .cppia, view updates without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)