### PR TITLE
fix(SwiftGenerator): qualify ForEach + subscript refs with appState.

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -218,6 +218,18 @@ class SwiftGenerator {
                 // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
+                // Replace "0..<name.count" — the ForEach iteration header
+                // emits the bare state name, which would otherwise resolve
+                // to an unbound identifier inside ContentView's body when
+                // the state lives on the separate AppState object that the
+                // bridge codepath generates.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
+                // Replace "(name[" (subscript access from inside string
+                // interpolation: "\(name[i])"). Matched with the leading
+                // paren so we don't accidentally rewrite suffix matches in
+                // longer identifiers, and so we leave existing
+                // "\(__APPSTATE__name[" alone (placeholder already in).
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -230,6 +230,14 @@ class SwiftGenerator {
                 // longer identifiers, and so we leave existing
                 // "\(__APPSTATE__name[" alone (placeholder already in).
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
+                // Replace "!name[" (logical-not subscript) and " name["
+                // (statement-leading bare reference inside CustomSwift
+                // bodies). Two narrow lookbehinds rather than a generic
+                // `name[` to avoid false-positives where the state name
+                // appears as a suffix of another identifier.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "!" + n + "[", "!" + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, " " + n + "[", " " + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "=" + n + "[", "=" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");


### PR DESCRIPTION
## Summary

When `@:expose` bridge functions exist, the macro splits state out into a separate `AppState` object instead of keeping it as `@State` on the ContentView. The existing pass through `bodySwift` replaces `\$name`, `\(name)`, `{name}`, `name = `, `if name` with the `appState.` prefix, but leaves two patterns alone:

- `0..<name.count` — the ForEach iteration header.
- `(name[…])` — array subscripts inside string interpolations and other parenthesised contexts.

Both compile down to `cannot find 'name' in scope` because the identifier isn't on the ContentView. Add two more `StringTools.replace` passes for these patterns inside the same loop, before the placeholder is resolved.

## Repro

Any sui App with `@:expose` static functions and a `State<Array<String>>` field renders the array via ForEach — currently fails to compile. With this patch the generated ContentView correctly emits:

\`\`\`swift
ForEach(0..<appState.items.count, id: \.self) { i in
    Text("\(appState.items[i])")
}
\`\`\`

## Test plan

- [x] Tested on the Courrier Libre macOS calendar client: prior to the fix the sidebar over `State<Array<String>>` calendars wouldn't compile; with the fix the SwiftUI sidebar binds and renders the array.
- [ ] Existing examples still compile (`hello-world`, `async-fetch`, `todo-app`, `components`).