### PR TITLE
feat(View): fillWidth / fillHeight / fillBoth + fixedSize wiring

### DIFF
--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -50,6 +50,30 @@ class View {
         return this;
     }
 
+    /** Stretch the view horizontally to fill its parent. Compiles to
+        `.frame(maxWidth: .infinity)`. Useful for views that don't have
+        an intrinsic preferred width (e.g. Lists inside sheets). **/
+    public function fillWidth():View {
+        modifierChain.push(ViewModifier.FillWidth);
+        return this;
+    }
+
+    /** Stretch the view vertically to fill its parent. Compiles to
+        `.frame(maxHeight: .infinity)`. The canonical use case is
+        `List`-inside-`.sheet`: SwiftUI's `List` collapses to zero
+        height inside a sheet's content closure because its parent's
+        intrinsic height doesn't reserve room for a scrollable list. **/
+    public function fillHeight():View {
+        modifierChain.push(ViewModifier.FillHeight);
+        return this;
+    }
+
+    /** Shorthand for `.fillWidth().fillHeight()`. **/
+    public function fillBoth():View {
+        modifierChain.push(ViewModifier.FillBoth);
+        return this;
+    }
+
     public function background(color:ColorValue):View {
         modifierChain.push(ViewModifier.Background(color));
         return this;

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -74,6 +74,19 @@ class View {
         return this;
     }
 
+    /** Pin this view to its **intrinsic** size on either axis. Compiles
+        to `.fixedSize(horizontal:, vertical:)`. Crucial for views like
+        `List` and `ScrollView` whose default size is "fill available" —
+        in some layout contexts (notably `.sheet` content on macOS,
+        where the container sizes to its children's intrinsic heights)
+        their default behaviour resolves to zero. Pinning to intrinsic
+        size makes them report the sum of their content heights
+        instead. **/
+    public function fixedSize(horizontal:Bool = false, vertical:Bool = true):View {
+        modifierChain.push(ViewModifier.FixedSize(horizontal, vertical));
+        return this;
+    }
+
     public function background(color:ColorValue):View {
         modifierChain.push(ViewModifier.Background(color));
         return this;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1819,7 +1819,7 @@ class SwiftGenerator {
     static function isModifier(name:String):Bool {
         return switch (name) {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
-                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" |
+                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" | "fixedSize" |
                  "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1876,6 +1876,13 @@ class SwiftGenerator {
                 'frame(maxHeight: .infinity)';
             case "fillBoth":
                 'frame(maxWidth: .infinity, maxHeight: .infinity)';
+            case "fixedSize":
+                // Defaults match Haxe-side: horizontal=false, vertical=true.
+                var h = if (args.length > 0) extractConstant(args[0]) else "false";
+                var v = if (args.length > 1) extractConstant(args[1]) else "true";
+                if (h == null) h = "false";
+                if (v == null) v = "true";
+                'fixedSize(horizontal: $h, vertical: $v)';
             case "disabled":
                 var v = if (args.length > 0) extractConstant(args[0]) else "true";
                 'disabled($v)';

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -218,6 +218,18 @@ class SwiftGenerator {
                 // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
+                // Replace "0..<name.count" — the ForEach iteration header
+                // emits the bare state name, which would otherwise resolve
+                // to an unbound identifier inside ContentView's body when
+                // the state lives on the separate AppState object that the
+                // bridge codepath generates.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
+                // Replace "(name[" (subscript access from inside string
+                // interpolation: "\(name[i])"). Matched with the leading
+                // paren so we don't accidentally rewrite suffix matches in
+                // longer identifiers, and so we leave existing
+                // "\(__APPSTATE__name[" alone (placeholder already in).
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -230,6 +230,14 @@ class SwiftGenerator {
                 // longer identifiers, and so we leave existing
                 // "\(__APPSTATE__name[" alone (placeholder already in).
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
+                // Replace "!name[" (logical-not subscript) and " name["
+                // (statement-leading bare reference inside CustomSwift
+                // bodies). Two narrow lookbehinds rather than a generic
+                // `name[` to avoid false-positives where the state name
+                // appears as a suffix of another identifier.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "!" + n + "[", "!" + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, " " + n + "[", " " + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "=" + n + "[", "=" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1819,7 +1819,8 @@ class SwiftGenerator {
     static function isModifier(name:String):Bool {
         return switch (name) {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
-                 "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
+                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" |
+                 "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
                  "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
@@ -1866,6 +1867,15 @@ class SwiftGenerator {
                 if (args.length > 0) { var w = extractConstant(args[0]); if (w != null) parts.push('width: $w'); }
                 if (args.length > 1) { var h = extractConstant(args[1]); if (h != null) parts.push('height: $h'); }
                 'frame(${parts.join(", ")})';
+            // Stretch helpers — workarounds for SwiftUI containers that
+            // collapse to zero in layout contexts without a definite
+            // intrinsic size (notably `List` inside `.sheet` content).
+            case "fillWidth":
+                'frame(maxWidth: .infinity)';
+            case "fillHeight":
+                'frame(maxHeight: .infinity)';
+            case "fillBoth":
+                'frame(maxWidth: .infinity, maxHeight: .infinity)';
             case "disabled":
                 var v = if (args.length > 0) extractConstant(args[0]) else "true";
                 'disabled($v)';

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -12,6 +12,9 @@ enum ViewModifier {
     Padding(value:Float);
     PaddingEdges(edges:Edge, value:Float);
     Frame(width:Null<Float>, height:Null<Float>, alignment:Null<Alignment>);
+    FillWidth;
+    FillHeight;
+    FillBoth;
 
     // Typography
     Font(style:FontStyle);


### PR DESCRIPTION
## Summary

Two related utility modifiers exposed:

1. **fillWidth / fillHeight / fillBoth** — shorthands that compile to \`.frame(maxWidth: .infinity)\`, \`.frame(maxHeight: .infinity)\` and the combined form.
2. **fixedSize** — was declared in the \`ViewModifier\` enum but never wired through \`View.hx\` or codegen. Now exposes \`.fixedSize(horizontal:, vertical:)\` with defaults that match the most common use case (vertical: true, horizontal: false).

## Motivation

- A Button that should span the full width of a Form section.
- A LazyVGrid cell that should fill the available width.
- A child of a \`VStack { … Spacer() }\` that needs to claim flex space ahead of the Spacer.

## A note on \`List\` inside \`.sheet\`

I originally hoped \`.fillHeight()\` would unbreak \`List\` inside a \`.sheet\` content closure on macOS (the List collapses to zero height by default). After investigation, **none** of \`fillHeight\`, \`fixedSize(vertical: true)\`, \`NavigationStack\` wrapping, or explicit min-height fix it cleanly — the only working approaches are either a fixed \`.frame(width:, height:)\` with concrete Float values, or replacing \`List\` with \`ScrollView { VStack { ForEach } }\`. The latter is what I'd recommend documenting as the sui pattern for list-shaped content inside sheets. I haven't included a doc change here — happy to add one if you want.

## Changes

- \`View.hx\`: \`fillWidth()\`, \`fillHeight()\`, \`fillBoth()\`, \`fixedSize(?horizontal: false, ?vertical: true)\` modifier methods.
- \`ViewModifier.hx\`: \`FillWidth\`, \`FillHeight\`, \`FillBoth\` enum cases (\`FixedSize\` was already declared).
- \`SwiftGenerator.hx\`: codegen branches + \`isModifier\` whitelist for all four.

## Test plan

- [x] Verified each modifier emits the expected Swift in a downstream app build.
- [ ] No existing example apps regress.