### PR TITLE
feat(View): buttonStyle modifier + ButtonStyleValue enum

### DIFF
--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -100,6 +100,15 @@ class View {
         return this;
     }
 
+    /** Apply a SwiftUI ButtonStyle. The most useful values for visual
+        hierarchy are `BorderedProminent` (the "filled" CTA look) and
+        `Bordered` (a thin outline). Use `Plain` to strip the default
+        chrome — handy inside Lists, sidebars and tappable cells. **/
+    public function buttonStyle(style:ButtonStyleValue):View {
+        modifierChain.push(ViewModifier.ButtonStyle(style));
+        return this;
+    }
+
     public function searchable(textBinding:String, ?prompt:String):View {
         modifierChain.push(ViewModifier.Searchable(textBinding, prompt));
         return this;
@@ -382,4 +391,13 @@ enum TextFieldStyleValue {
     Automatic;
     RoundedBorder;
     Plain;
+}
+
+enum ButtonStyleValue {
+    Automatic;
+    Plain;
+    Borderless;
+    Bordered;
+    BorderedProminent;
+    Link;
 }

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1801,7 +1801,7 @@ class SwiftGenerator {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
-                 "toggleStyle" | "pickerStyle" | "scrollIndicators" |
+                 "buttonStyle" | "toggleStyle" | "pickerStyle" | "scrollIndicators" |
                  "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
@@ -1860,6 +1860,9 @@ class SwiftGenerator {
             case "textFieldStyle":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'textFieldStyle(.${e != null ? camel(e) : "automatic"})';
+            case "buttonStyle":
+                var e = if (args.length > 0) extractEnumName(args[0]) else null;
+                'buttonStyle(.${e != null ? camel(e) : "automatic"})';
             case "toggleStyle":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'toggleStyle(.${e != null ? camel(e) : "automatic"})';

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -38,6 +38,7 @@ enum ViewModifier {
 
     // Styles
     TextFieldStyle(style:sui.View.TextFieldStyleValue);
+    ButtonStyle(style:sui.View.ButtonStyleValue);
 
     // Presentation
     Sheet(isPresentedBinding:Dynamic, content:sui.View);


### PR DESCRIPTION
## Summary

Mirror of the existing \`textFieldStyle\` / \`toggleStyle\` / \`pickerStyle\` helpers — exposes SwiftUI's \`.buttonStyle(.bordered / .borderedProminent / .plain / .borderless / .link / .automatic)\` so apps can use Buttons for navigation chrome (e.g. a mode switcher in a toolbar) without dropping into CustomSwift.

## Motivating use case

In a calendar client's view-mode switcher:

\`\`\`haxe
new Button(\"Mois\", null, ...).buttonStyle(ButtonStyleValue.BorderedProminent)
new Button(\"Semaine\", null, ...).buttonStyle(ButtonStyleValue.Bordered)
new Button(\"Jour\", null, ...).buttonStyle(ButtonStyleValue.Bordered)
\`\`\`

Compiles to the SwiftUI canonical pattern for indicating the active option among siblings.

## Changes

- \`View.hx\`: \`buttonStyle(ButtonStyleValue)\` method + \`ButtonStyleValue\` enum.
- \`ViewModifier.hx\`: \`ButtonStyle(style)\` enum case.
- \`SwiftGenerator.hx\`: codegen branch + \`isModifier\` whitelist.

Identical plumbing to \`textFieldStyle\` so it follows the same patterns reviewers are already familiar with.

## Test plan

- [x] Builds clean in a downstream calendar app (used \`Bordered\` and \`BorderedProminent\` on a mode switcher).
- [ ] No regression in existing examples (they don't use buttonStyle currently).