### PR TITLE
feat(View): foregroundHex / backgroundHex from state (with Color(suiHex:) runtime)

### DIFF
--- a/runtime/swift/ViewBridge.swift
+++ b/runtime/swift/ViewBridge.swift
@@ -11,3 +11,27 @@ extension HaxeView {
     func haxeOnAppear() {}
     func haxeOnDisappear() {}
 }
+
+/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB" or 3-digit shorthand.
+/// Returns `nil` for invalid input so call sites can fall back via the
+/// nil-coalescing operator: `Color(suiHex: appState.calendarColor) ?? .primary`.
+///
+/// Used by sui's foregroundHex / backgroundHex modifiers — codegen emits
+/// the optional-fallback expression so user state values that aren't
+/// well-formed hex don't crash the SwiftUI body.
+extension Color {
+    init?(suiHex: String) {
+        var s = suiHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        if s.count == 3 {
+            s = s.map { "\($0)\($0)" }.joined()
+        }
+        guard s.count == 6,
+              let v = UInt32(s, radix: 16)
+        else { return nil }
+        let r = Double((v >> 16) & 0xFF) / 255.0
+        let g = Double((v >> 8) & 0xFF) / 255.0
+        let b = Double(v & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -45,6 +45,25 @@ class View {
         return this;
     }
 
+    /** Set the foreground colour from a hex string held in a state
+        variable. `expr` is emitted verbatim in the generated Swift body
+        and therefore picked up by the macro's state-prefix pass —
+        plain names like `calendarColor` resolve to
+        `appState.calendarColor`, and subscripted forms like
+        `calendarColors[i]` resolve to `appState.calendarColors[i]`
+        (the per-iteration case for ForEach). Invalid hex falls back to
+        `.primary` via the nil-coalescing operator on `Color(suiHex:)`. **/
+    public function foregroundHex(expr:String):View {
+        modifierChain.push(ViewModifier.ForegroundHex(expr));
+        return this;
+    }
+
+    /** Same as `foregroundHex` but for the background fill. **/
+    public function backgroundHex(expr:String):View {
+        modifierChain.push(ViewModifier.BackgroundHex(expr));
+        return this;
+    }
+
     public function frame(?width:Float, ?height:Float, ?alignment:Alignment):View {
         modifierChain.push(ViewModifier.Frame(width, height, alignment));
         return this;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1798,7 +1798,8 @@ class SwiftGenerator {
 
     static function isModifier(name:String):Bool {
         return switch (name) {
-            case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
+            case "padding" | "font" | "foregroundColor" | "background" |
+                 "foregroundHex" | "backgroundHex" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1830,6 +1831,18 @@ class SwiftGenerator {
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'background(.${e != null ? camel(e) : "clear"})';
+            case "foregroundHex":
+                // The expression is embedded verbatim and run through the
+                // body's appState-prefix pass — so bare names like
+                // `calendarColor` or subscripted names like
+                // `calendarColors[i]` resolve correctly at the call site.
+                var expr = if (args.length > 0) extractString(args[0]) else null;
+                if (expr == null) expr = "\"\"";
+                'foregroundStyle(Color(suiHex: ${expr}) ?? Color.primary)';
+            case "backgroundHex":
+                var expr = if (args.length > 0) extractString(args[0]) else null;
+                if (expr == null) expr = "\"\"";
+                'background(Color(suiHex: ${expr}) ?? Color.clear)';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -22,6 +22,8 @@ enum ViewModifier {
     // Colors & Appearance
     ForegroundColor(color:ColorValue);
     Background(color:ColorValue);
+    ForegroundHex(expr:String);
+    BackgroundHex(expr:String);
     Opacity(value:Float);
 
     // Shape


### PR DESCRIPTION
## Summary

Lets apps bind a view's fill or text colour to a hex string stored in sui State, including the per-iteration case inside ForEach where the hex lives in a \`State<Array<String>>\` indexed by the loop variable.

## Why

The existing \`foregroundColor\` / \`background\` modifiers take a static \`ColorValue\` enum, so any data-driven palette (calendar dots in a sidebar, per-status tags, brand colours per row) had to fall back to \`CustomSwift\` or coloured emoji prefixes. Both are awkward and lose the actual brand colour.

Motivating case — sidebar puck colours in a calendar app:

\`\`\`haxe
new ForEach(calendarNames, \"i\", new HStack(null, 8, [
  new Text(\"●\").foregroundHex(\"calendarColors[i]\"),
  Text.withState(\"{calendarNames[i]}\"),
]))
\`\`\`

## How

- Two new modifiers \`foregroundHex(expr:String)\` and \`backgroundHex(expr:String)\`. \`expr\` is the Swift expression the user wants to read at runtime — typically a bare state name like \`calendarColor\` or a subscripted form like \`calendarColors[i]\`. It's emitted verbatim into the generated body and goes through the macro's existing appState-prefix pass, so it resolves correctly in both top-level and ForEach contexts.
- Codegen wraps in nil-coalescing — \`Color(suiHex: …) ?? Color.primary\` — so a malformed hex value doesn't crash SwiftUI's body evaluation.
- New \`Color(suiHex:)\` Swift initialiser in \`runtime/swift/ViewBridge.swift\` parses \"#RRGGBB\", \"RRGGBB\" and 3-digit shorthand. Returns nil on bad input so the call sites can fall back cleanly.

## Test plan

- [x] Used downstream in a calendar client's sidebar: a ForEach over \`State<Array<String>>\` calendar colours renders correct per-row puck colours.
- [x] Malformed hex (\`\"\"\`, \`\"foo\"\`) gracefully falls back to \`.primary\` rather than crashing.
- [ ] No regressions in existing examples (none of them use hex colours).