### PR TITLE
Make the C bridge thread-safe and exception-safe

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -471,7 +471,9 @@ class SwiftGenerator {
             buf.add('#include "sui/ui/Button.h"\n');
         }
         buf.add('#include "sui/state/State.h"\n');
-        buf.add("#include <string.h>\n\n");
+        buf.add("#include <string.h>\n");
+        buf.add("#include <mutex>\n");
+        buf.add("#include <cstdio>\n\n");
         buf.add("// Auto-generated bridge: calls into hxcpp-compiled Haxe code.\n\n");
 
         buf.add("extern \"C\" void __hxcpp_lib_main() {}\n");
@@ -481,6 +483,43 @@ class SwiftGenerator {
             buf.add("extern \"C\" void haxe_bridge_register_state_fn(void (*)(const char*, const char*));\n");
         }
         buf.add("\n");
+
+        // ── Bridge safety scaffold ────────────────────────────────
+        //
+        // Every entry into this file ends up running hxcpp-compiled
+        // Haxe code, which:
+        //   1) requires the calling thread's stack to be registered as
+        //      a GC root via hx::SetTopOfStack, and
+        //   2) is *not* internally synchronized — two threads running
+        //      Haxe at once is undefined behaviour.
+        //
+        // SwiftUI clients hit case 2 the moment they mix
+        //   - computed properties that query state on every body re-eval
+        //     (the closure form of ForEach lands here), and
+        //   - `Task.detached { HaxeBridgeC.foo(...) }` for any user
+        //     `@:expose`d function.
+        //
+        // We serialize both with a single global recursive_mutex.
+        // Recursive is necessary because Haxe→Swift callbacks
+        // (`_bridge_state_forwarder`) can in turn invoke other bridge
+        // entrypoints, all on the same thread.
+        //
+        // Each entrypoint also wraps the call in try/catch — an
+        // uncaught Haxe `throw` walks past `__cxa_throw` and aborts
+        // the process; without the catch we have no way to surface
+        // the error to Swift.
+        buf.add("static std::recursive_mutex _haxe_runtime_mutex;\n\n");
+
+        buf.add("struct HaxeBridgeScope {\n");
+        buf.add("    std::lock_guard<std::recursive_mutex> _lock;\n");
+        buf.add("    int _gc_dummy;\n");
+        buf.add("    HaxeBridgeScope() : _lock(_haxe_runtime_mutex), _gc_dummy(0) {\n");
+        buf.add("        hx::SetTopOfStack(&_gc_dummy, true);\n");
+        buf.add("    }\n");
+        buf.add("    ~HaxeBridgeScope() {\n");
+        buf.add("        hx::SetTopOfStack((int*)0, true);\n");
+        buf.add("    }\n");
+        buf.add("};\n\n");
 
         if (hasRuntimeActions) {
             // State callback: Swift → C → Haxe State.set() → C → Swift AppState
@@ -495,125 +534,113 @@ class SwiftGenerator {
             buf.add("}\n\n");
         }
 
-        // haxe_bridge_init: boots hxcpp runtime, registers callbacks, builds view tree
+        // haxe_bridge_init: boots hxcpp runtime, registers callbacks, builds view tree.
+        // Boot itself isn't reentrant, so we hold the lock for the whole init body.
         buf.add("void haxe_bridge_init(void) {\n");
+        buf.add("    std::lock_guard<std::recursive_mutex> _lock(_haxe_runtime_mutex);\n");
         buf.add("    int dummy = 0;\n");
         buf.add("    hx::SetTopOfStack(&dummy, true);\n");
-        buf.add("    hx::Boot();\n");
-        buf.add("    __boot_all();\n");
-
+        buf.add("    try {\n");
+        buf.add("        hx::Boot();\n");
+        buf.add("        __boot_all();\n");
         if (hasRuntimeActions) {
-            buf.add("\n    // Register state change forwarder (State.set() → Swift AppState)\n");
-            buf.add("    haxe_bridge_register_state_fn(_bridge_state_forwarder);\n");
-            buf.add("\n    // Build view tree to register button actions\n");
-            buf.add('    auto app = ::${appClassName}_obj::__new();\n');
-            buf.add("    app->body();\n");
+            buf.add("        // Register state change forwarder (State.set() → Swift AppState)\n");
+            buf.add("        haxe_bridge_register_state_fn(_bridge_state_forwarder);\n");
+            buf.add("        // Build view tree to register button actions\n");
+            buf.add('        auto app = ::${appClassName}_obj::__new();\n');
+            buf.add("        app->body();\n");
         }
-
+        buf.add("    } catch (::Dynamic _e) {\n");
+        buf.add('        fprintf(stderr, "[sui] haxe_bridge_init: Haxe exception during boot\\n");\n');
+        buf.add("    } catch (...) {\n");
+        buf.add('        fprintf(stderr, "[sui] haxe_bridge_init: C++ exception during boot\\n");\n');
+        buf.add("    }\n");
         buf.add("}\n\n");
 
         if (hasRuntimeActions) {
             // invoke_action: calls into Haxe Button action registry
             buf.add("void haxe_bridge_invoke_action(int32_t actionId) {\n");
-            buf.add("    // Set up hxcpp thread-local storage for this thread\n");
-            buf.add("    // (needed when called from Swift Task.detached background threads)\n");
-            buf.add("    int dummy = 0;\n");
-            buf.add("    hx::SetTopOfStack(&dummy, true);\n");
-            buf.add("    ::sui::ui::Button_obj::_invokeAction(actionId);\n");
-            buf.add("    hx::SetTopOfStack((int*)0, true);\n");
+            buf.add("    HaxeBridgeScope _scope;\n");
+            buf.add("    try {\n");
+            buf.add("        ::sui::ui::Button_obj::_invokeAction(actionId);\n");
+            buf.add("    } catch (::Dynamic _e) {\n");
+            buf.add('        fprintf(stderr, "[sui] haxe_bridge_invoke_action: Haxe exception\\n");\n');
+            buf.add("    } catch (...) {\n");
+            buf.add('        fprintf(stderr, "[sui] haxe_bridge_invoke_action: C++ exception\\n");\n');
+            buf.add("    }\n");
             buf.add("}\n\n");
         }
 
-        // Shared-memory query functions — typed accessors avoid serialization
-        // Helper macro pattern: GC setup, call, GC teardown
-        buf.add("// Array length\n");
-        buf.add("int32_t haxe_bridge_array_length(const char* stateName) {\n");
-        buf.add("    if (!stateName) return -1;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getArrayLength(::String(stateName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        // ── Shared-memory query functions ─────────────────────────
+        emitSharedMemoryReader(buf, "haxe_bridge_array_length",
+            "int32_t", "0",
+            "if (!stateName) return -1;\n",
+            "(int32_t)::sui::state::State_obj::_getArrayLength(::String(stateName))",
+            "stateName.c_str", null,
+            "int32_t");
 
-        // String element
-        buf.add("const char* haxe_bridge_array_string_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return \"\";\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    ::String r = ::sui::state::State_obj::_getArrayStringElement(::String(stateName), (int)index);\n");
-        buf.add("    static thread_local char _buf[4096];\n");
-        buf.add("    strncpy(_buf, r.__CStr(), sizeof(_buf) - 1); _buf[sizeof(_buf) - 1] = 0;\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return _buf;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_string_element",
+            "const char*", "\"\"",
+            "if (!stateName) return \"\";\n",
+            "::sui::state::State_obj::_getArrayStringElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", "haxe_string_to_buf",
+            "::String");
 
-        // Int element — no string conversion
-        buf.add("int32_t haxe_bridge_array_int_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return 0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getArrayIntElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_int_element",
+            "int32_t", "0",
+            "if (!stateName) return 0;\n",
+            "(int32_t)::sui::state::State_obj::_getArrayIntElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "int32_t");
 
-        // Float element — no string conversion
-        buf.add("double haxe_bridge_array_float_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return 0.0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    double r = (double)::sui::state::State_obj::_getArrayFloatElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_float_element",
+            "double", "0.0",
+            "if (!stateName) return 0.0;\n",
+            "(double)::sui::state::State_obj::_getArrayFloatElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "double");
 
-        // Bool element — no string conversion
-        buf.add("bool haxe_bridge_array_bool_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return false;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    bool r = (bool)::sui::state::State_obj::_getArrayBoolElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_bool_element",
+            "bool", "false",
+            "if (!stateName) return false;\n",
+            "(bool)::sui::state::State_obj::_getArrayBoolElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "bool");
 
-        // Object field accessors
-        buf.add("const char* haxe_bridge_object_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return \"\";\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    ::String r = ::sui::state::State_obj::_getObjectField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    static thread_local char _buf[4096];\n");
-        buf.add("    strncpy(_buf, r.__CStr(), sizeof(_buf) - 1); _buf[sizeof(_buf) - 1] = 0;\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return _buf;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_field",
+            "const char*", "\"\"",
+            "if (!stateName || !fieldName) return \"\";\n",
+            "::sui::state::State_obj::_getObjectField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", "haxe_string_to_buf",
+            "::String");
 
-        buf.add("int32_t haxe_bridge_object_int_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return 0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getObjectIntField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_int_field",
+            "int32_t", "0",
+            "if (!stateName || !fieldName) return 0;\n",
+            "(int32_t)::sui::state::State_obj::_getObjectIntField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "int32_t");
 
-        buf.add("double haxe_bridge_object_float_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return 0.0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    double r = (double)::sui::state::State_obj::_getObjectFloatField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_float_field",
+            "double", "0.0",
+            "if (!stateName || !fieldName) return 0.0;\n",
+            "(double)::sui::state::State_obj::_getObjectFloatField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "double");
 
-        buf.add("bool haxe_bridge_object_bool_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return false;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    bool r = (bool)::sui::state::State_obj::_getObjectBoolField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_bool_field",
+            "bool", "false",
+            "if (!stateName || !fieldName) return false;\n",
+            "(bool)::sui::state::State_obj::_getObjectBoolField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "bool");
 
+        // ── User-defined @:expose functions ───────────────────────
         for (fn in fns) {
             var cParams = [for (p in fn.params) '${swiftTypeToCType(p.swiftType)} ${p.name}'];
             if (cParams.length == 0) cParams.push("void");
-            buf.add('${swiftTypeToCType(fn.returnType)} haxe_bridge_${fn.name}(${cParams.join(", ")}) {\n');
-            buf.add("    int _gc_dummy = 0;\n");
-            buf.add("    hx::SetTopOfStack(&_gc_dummy, true);\n");
+            var cReturnType = swiftTypeToCType(fn.returnType);
+            buf.add('$cReturnType haxe_bridge_${fn.name}(${cParams.join(", ")}) {\n');
 
             // Build hxcpp call arguments
             var hxArgs:Array<String> = [];
@@ -628,36 +655,112 @@ class SwiftGenerator {
             }
 
             var call = '::${appClassName}_obj::${fn.name}(${hxArgs.join(", ")})';
+            var fnName = fn.name;
 
             switch (fn.returnType) {
                 case "String":
-                    buf.add('    ::String _hx_result = $call;\n');
-                    buf.add("    static thread_local char _buf[4096];\n");
-                    buf.add("    const char* _cstr = _hx_result.__CStr();\n");
-                    buf.add("    strncpy(_buf, _cstr, sizeof(_buf) - 1);\n");
-                    buf.add("    _buf[sizeof(_buf) - 1] = 0;\n");
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _buf;\n");
+                    buf.add('    static thread_local char _buf[4096];\n');
+                    buf.add('    _buf[0] = 0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try {\n');
+                    buf.add('            ::String _hx_result = $call;\n');
+                    buf.add('            const char* _cstr = _hx_result.__CStr();\n');
+                    buf.add('            strncpy(_buf, _cstr, sizeof(_buf) - 1);\n');
+                    buf.add('            _buf[sizeof(_buf) - 1] = 0;\n');
+                    buf.add('        } catch (::Dynamic _e) {\n');
+                    buf.add('            fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n");\n');
+                    buf.add('        } catch (...) {\n');
+                    buf.add('            fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n");\n');
+                    buf.add('        }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _buf;\n');
                 case "Int":
-                    buf.add('    int32_t _ret = (int32_t)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    int32_t _ret = 0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (int32_t)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 case "Double" | "Float":
-                    buf.add('    double _ret = (double)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    double _ret = 0.0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (double)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 case "Bool":
-                    buf.add('    bool _ret = (bool)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    bool _ret = false;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (bool)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 default:
-                    buf.add('    $call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
+                    buf.add('    HaxeBridgeScope _scope;\n');
+                    buf.add('    try { $call; }\n');
+                    buf.add('    catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('    catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
             }
 
             buf.add("}\n\n");
         }
         return buf.toString();
+    }
+
+    /** Helper for the shared-memory state readers. They all share the
+        same shape: a guard, a HaxeBridgeScope, a try/catch around the
+        Haxe call, and either a numeric return or a thread-local
+        buffer for String returns. The macro-level abstraction keeps
+        the bridge body small and consistent. **/
+    static function emitSharedMemoryReader(buf:StringBuf, fnName:String,
+            cReturnType:String, defaultReturn:String, guard:String,
+            call:String, _:String, stringMode:Null<String>, hxResultType:String):Void {
+        var isString = (stringMode == "haxe_string_to_buf");
+        // Reconstruct the C parameter list from the function name —
+        // the naming convention is enough to discriminate.
+        var params = if (fnName.indexOf("object") >= 0)
+            "const char* stateName, int32_t index, const char* fieldName";
+        else if (fnName.indexOf("element") >= 0)
+            "const char* stateName, int32_t index";
+        else
+            "const char* stateName";
+        buf.add('$cReturnType ${fnName}($params) {\n');
+        buf.add('    $guard');
+        if (isString) {
+            buf.add('    static thread_local char _buf[4096];\n');
+            buf.add('    _buf[0] = 0;\n');
+        } else {
+            buf.add('    $cReturnType _ret = $defaultReturn;\n');
+        }
+        buf.add('    {\n');
+        buf.add('        HaxeBridgeScope _scope;\n');
+        buf.add('        try {\n');
+        if (isString) {
+            buf.add('            ::String r = $call;\n');
+            buf.add('            strncpy(_buf, r.__CStr(), sizeof(_buf) - 1);\n');
+            buf.add('            _buf[sizeof(_buf) - 1] = 0;\n');
+        } else {
+            buf.add('            _ret = $call;\n');
+        }
+        buf.add('        } catch (::Dynamic _e) {\n');
+        buf.add('            fprintf(stderr, "[sui] ${fnName}: Haxe exception\\n");\n');
+        buf.add('        } catch (...) {\n');
+        buf.add('            fprintf(stderr, "[sui] ${fnName}: C++ exception\\n");\n');
+        buf.add('        }\n');
+        buf.add('    }\n');
+        if (isString) {
+            buf.add('    return _buf;\n');
+        } else {
+            buf.add('    return _ret;\n');
+        }
+        buf.add('}\n\n');
     }
 
     static function generateBridgeSwift(appClassName:String, fns:Array<{name:String, params:Array<{name:String, swiftType:String}>, returnType:String}>, hasRuntimeActions:Bool):String {


### PR DESCRIPTION
## Summary

The Haxe runtime under `HaxeBridgeC` had two latent footguns SwiftUI clients hit reliably once they got past hello-world:

**1. Concurrent re-entry was undefined.**
The closure form of `ForEach` wires a Swift computed property that calls `HaxeBridgeC.arrayLength(_:)` and `HaxeBridgeC.arrayStringElement(_:at:)` on every body re-evaluation; meanwhile any `Task.detached` invoking a `@:expose`d user function runs on a cooperative-pool thread. Both called `hx::SetTopOfStack` and then ran Haxe code with no synchronization — racing on GC bookkeeping for the same process. Random `EXC_BAD_ACCESS` crashes were observable inside simple operations like `String` concatenation.

**2. Uncaught Haxe exceptions aborted the app.**
Each bridge body called the Haxe method without a `try` block, so any `throw` — network error, null dereference, anything — walked up through `__cxa_throw` and called `std::terminate()`. No way for Swift to surface the error.

## Fix

`generateBridgeCpp` now emits, once per generated `HaxeBridgeC.cpp`:

```cpp
static std::recursive_mutex _haxe_runtime_mutex;

struct HaxeBridgeScope {
    std::lock_guard<std::recursive_mutex> _lock;
    int _gc_dummy;
    HaxeBridgeScope() : _lock(_haxe_runtime_mutex), _gc_dummy(0) {
        hx::SetTopOfStack(&_gc_dummy, true);
    }
    ~HaxeBridgeScope() {
        hx::SetTopOfStack((int*)0, true);
    }
};
```

…and every entrypoint (init, invoke_action, the 8 shared-memory readers, every user `@:expose` function) now follows the same shape:

```cpp
T haxe_bridge_foo(args) {
    // input guards
    HaxeBridgeScope _scope;
    try {
        // call Haxe, fill return value
    } catch (::Dynamic _e) { fprintf(stderr, "..."); }
    catch (...) { fprintf(stderr, "..."); }
    return _ret;
}
```

The mutex is `recursive` because Haxe→Swift state callbacks (`_bridge_state_forwarder`) can in turn call other bridge entrypoints from the same thread — non-recursive would self-deadlock.

The 8 nearly-identical shared-memory readers were factored out into `emitSharedMemoryReader` to avoid copy-paste drift.

## Why this matters

`@:expose` functions that throw used to abort the process. With this PR they return their typed default (`0`, `false`, `""`, etc.) and log to stderr. Callers in Swift can decide what to do (most already check for empty strings). It is now safe to write Haxe code that propagates exceptions, e.g. HTTP failures inside `Task.detached { HaxeBridgeC.saveX(payload) }`.

Mixing closure-form `ForEach` (#61) with `Task.detached` bridge calls no longer corrupts the GC.

## Test plan

- [x] `examples/bridge-demo` rebuilds; generated `HaxeBridgeC.cpp` shows every entrypoint inside the new scaffold
- [x] Existing examples (hello-world, todo-app, etc.) still build
- [x] Diff is mechanical — boilerplate factored out, no semantic changes besides the mutex + try/catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)