### PR TITLE
Don't inline static factories that carry @:swiftName

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1580,6 +1580,16 @@ class SwiftGenerator {
     /** Try to inline a view-returning function call. Returns null if not resolvable. **/
     static function tryInlineViewCall(field:haxe.macro.Type.ClassField, args:Array<haxe.macro.Type.TypedExpr>, indent:Int):String {
         if (!returnsView(field)) return null;
+        // Static factories that carry @:swiftName have their own Swift
+        // emission (`generateSwiftCall` reads :swiftLabel-tagged params
+        // and builds the matching initializer call) — inlining them
+        // would walk the Haxe body and ignore those annotations,
+        // emitting whatever stub the factory uses internally. The
+        // canonical case is `Image.systemImage(...)` whose body builds
+        // `new Image("")` as a placeholder, so without this guard the
+        // generated Swift came out as `Image("")` instead of
+        // `Image(systemName: "...")`.
+        if (getMetaString(field.meta, ":swiftName") != null) return null;
         var funcExpr = field.expr();
         if (funcExpr == null) return null;
 


### PR DESCRIPTION
## Symptom

`Image.systemImage("circle.fill")` started emitting `Image("")` instead of `Image(systemName: "circle.fill")` in the generated Swift. Affects every consumer of SF Symbol images — `examples/ios-tabs` was the canary, but anything that uses a `@:swiftName`-tagged static factory hits this.

## Cause

`tryInlineViewCall` accepts any field that returns a `View` and walks its body via `walkFunc`. That's correct for plain Haxe view-returning helpers (e.g. a user's `function buildHeader():View { ... }`), but wrong for the static factory pattern used by `Image.systemImage`:

```haxe
@:swiftName("Image")
public static function systemImage(@:swiftLabel("systemName") systemName:String):Image {
    var img = new Image("");       // ← placeholder, what tryInlineViewCall walks
    img.systemName = systemName;
    return img;
}
```

The factory carries `@:swiftName("Image")` + `@:swiftLabel("systemName")` on the parameter, and `factoryToSwift`/`generateSwiftCall` know how to read those and emit `Image(systemName: "...")`. But `tryInlineViewCall` fires first and returns a non-null inlining result, so the metadata-driven path never runs.

## Fix

When a field has `@:swiftName`, that's a clean signal: "I have my own Swift emission, don't inline me." Adding the guard in `tryInlineViewCall` defers to the metadata path:

```haxe
if (getMetaString(field.meta, ":swiftName") != null) return null;
```

## Test plan

- [x] `examples/ios-tabs` builds and now emits `Image(systemName: "swift")` for `Image.systemImage("swift")` (previously `Image("")`)
- [x] Other examples still build (no regression on user-defined view helpers — they don't carry `@:swiftName`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)