### PR TITLE
Emit Color.accentColor for ColorValue.Accent in shape-style modifiers

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1826,10 +1826,10 @@ class SwiftGenerator {
                 'font(.${e != null ? camel(e) : "body"})';
             case "foregroundColor":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'foregroundStyle(.${e != null ? camel(e) : "primary"})';
+                'foregroundStyle(${colorEnumToSwift(e, "primary")})';
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'background(.${e != null ? camel(e) : "clear"})';
+                'background(${colorEnumToSwift(e, "clear")})';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":
@@ -1854,7 +1854,7 @@ class SwiftGenerator {
                 'lineLimit($v)';
             case "shadow":
                 var parts:Array<String> = [];
-                if (args.length > 0) { var e = extractEnumName(args[0]); if (e != null) parts.push('color: .${camel(e)}'); }
+                if (args.length > 0) { var e = extractEnumName(args[0]); if (e != null) parts.push('color: ${colorEnumToSwift(e, "primary")}'); }
                 if (args.length > 1) { var r = extractConstant(args[1]); if (r != null) parts.push('radius: $r'); }
                 'shadow(${parts.join(", ")})';
             case "textFieldStyle":
@@ -1955,7 +1955,7 @@ class SwiftGenerator {
                 'overlay {\n${contentSwift}${pad}}';
             case "tint":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'tint(.${e != null ? camel(e) : "accentColor"})';
+                'tint(${colorEnumToSwift(e, "accentColor")})';
             case "badge":
                 var v = if (args.length > 0) extractConstant(args[0]) else null;
                 if (v != null)
@@ -2235,6 +2235,23 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Translate a `ColorValue` enum-name into the Swift expression to
+        pass to a colour-consuming modifier (`foregroundStyle`,
+        `background`, `shadow`, `tint`, etc.). Most values map to the
+        dotted shorthand (`.red`, `.blue`, `.primary`, …) because
+        SwiftUI exposes them on every relevant `ShapeStyle`/`Color`
+        type. `Accent` is the exception: there is no `.accent`
+        `ShapeStyle` member, so we emit the explicit static
+        `Color.accentColor` instead, which is universally available
+        and works as both a `Color` and a `ShapeStyle`. **/
+    static function colorEnumToSwift(name:Null<String>, fallback:String):String {
+        if (name == null) return '.${fallback}';
+        return switch (name) {
+            case "Accent": "Color.accentColor";
+            default: '.${camel(name)}';
+        };
     }
 
     static function templateToSwift(template:String):String {


### PR DESCRIPTION
## Symptom

```haxe
new Text("…").foregroundColor(ColorValue.Accent)
```

```
error: type 'ShapeStyle' has no member 'accent'
```

Same error from `background(ColorValue.Accent)`, `shadow(ColorValue.Accent, …)`, and `tint(ColorValue.Accent)` (with an explicit Accent — the fallback path was already `accentColor`, but a user who spelled it out hit the bug).

## Cause

`foregroundColor`, `background`, `shadow` and `tint` built their Swift output by camel-casing the `ColorValue` enum name and dropping it in as dotted shorthand:

```haxe
'foregroundStyle(.${e != null ? camel(e) : "primary"})';
```

That works for the 14 simple cases (`Red`→`.red`, `Blue`→`.blue`, `Primary`→`.primary`, …) because SwiftUI exposes those on every relevant `ShapeStyle`/`Color` type. `Accent` is the odd one out: there is no `.accent` `ShapeStyle` member, and `Color.accent` only landed in iOS 17 / macOS 14.

## Fix

`Color.accentColor` is the documented, since-iOS-13/macOS-10.15 way to reference the accent colour and works as both `Color` and `ShapeStyle`. Added a small helper:

```haxe
static function colorEnumToSwift(name:Null<String>, fallback:String):String {
    if (name == null) return '.${fallback}';
    return switch (name) {
        case "Accent": "Color.accentColor";
        default: '.${camel(name)}';
    };
}
```

Routed `foregroundColor`, `background`, `shadow`, and `tint` through it. `tint`'s fallback (no enum supplied) already produced `.accentColor` — now consistent with the explicit `Accent` case.

## Test plan

- [x] Code that exercised `ColorValue.Accent` now compiles
- [x] The 14 simple `ColorValue` cases (Red/Blue/Green/etc.) go through the unchanged default branch and emit the same output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)