### PR TITLE
Propagate State initial values to AppState on boot

### DIFF
--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -165,10 +165,19 @@ class SwiftGenerator {
         appSwift.add("@main\n");
         appSwift.add('struct ${className}App: App {\n');
         appSwift.add("    init() {\n");
-        appSwift.add("        HaxeRuntime.initialize()\n");
         if (needsRuntimeBridge) {
+            // Register the swift-side state callback BEFORE the
+            // runtime boots. `HaxeRuntime.initialize()` calls
+            // `haxe_bridge_init`, which itself constructs the
+            // application class — any `State.setByName` (or
+            // `State<T>(initialValue, ...)` push) issued during the
+            // constructor only reaches AppState if the swift
+            // callback is already wired up. With the previous order
+            // those updates were dropped silently and AppState
+            // stayed on its literal defaults until the next mutation.
             appSwift.add("        HaxeBridgeC.registerCallbacks()\n");
         }
+        appSwift.add("        HaxeRuntime.initialize()\n");
         appSwift.add("    }\n\n");
         appSwift.add("    var body: some Scene {\n");
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');

--- a/src/sui/state/State.hx
+++ b/src/sui/state/State.hx
@@ -54,6 +54,25 @@ class State<T> {
         this.name = name != null ? name : "";
         if (this.name != "")
             _registry.set(this.name, this);
+        // Push the initial value across the bridge so AppState's
+        // Swift-side property — which the macro currently emits with a
+        // literal default (`""`, `false`, `0`, …) — picks up what Haxe
+        // intends. Without this, a `new State<Bool>(true, "isLoggedIn")`
+        // in the App constructor leaves Swift's `isLoggedIn` at `false`
+        // until the next mutation, which routinely causes the wrong
+        // initial view to render (re-login screen for an
+        // already-authenticated user, empty grids, …).
+        //
+        // Arrays go through the shared-memory bridge, so we still send
+        // an empty string — that bumps the version counter on the
+        // Swift side and triggers a fresh read.
+        #if cpp
+        if (this.name != "") {
+            var k = this.name;
+            var v = if (Std.isOfType(initialValue, Array)) "" else Std.string(initialValue);
+            untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', k, v);
+        }
+        #end
     }
 
     function get_value():T {


### PR DESCRIPTION
## Symptom

```haxe
class App extends sui.App {
    public var isLoggedIn:State<Bool>;
    public function new() {
        super();
        var token = Tokens.load();
        var logged = token != null && !token.isExpired();
        isLoggedIn = new State<Bool>(logged, "isLoggedIn"); // ← lost
    }
}
```

`AppState.isLoggedIn` stays `false` and the wrong branch of any `ConditionalView(isLoggedIn, …)` renders until something later mutates `isLoggedIn`. In real apps this looked like "I have to log in every time I launch" even though the token is sitting in the Keychain.

Same flavour of bug for any state that the user seeds from a config file / Keychain / boot-time computation.

## Root cause

Two independent bugs combined:

1. **Callback registered after init.** Generated `App.swift` did
   ```swift
   HaxeRuntime.initialize()     // → haxe_bridge_init → App constructor + body()
   HaxeBridgeC.registerCallbacks()
   ```
   so during `haxe_bridge_init`, the swift-side `_swift_state_cb` was still `nil`. Any `State.setByName(...)` issued from the constructor hit a null callback in `_bridge_state_forwarder` and was silently dropped.

2. **`State<T>` constructor never pushed.** Only `set_value` fired `_hxsui_notify_swift`. So even with the callback wired up, `new State<Bool>(true, "isLoggedIn")` left Swift's literal default in place — nothing told AppState the new instance had a non-default value.

## Fix

- **App.swift order swap.** `registerCallbacks()` now runs *before* `HaxeRuntime.initialize()`. The callback registration just stores a function pointer — it doesn't enter Haxe — so it's safe to do before the runtime is booted.
- **Constructor push.** `State<T>`'s constructor now mirrors `set_value`'s notify path: empty string for arrays (so the shared-memory version counter bumps and the Swift side re-reads), `Std.string(value)` for everything else.

Together these mean the first `body` render observes the values the constructor intended, instead of the literal defaults the generated AppState was initialized with.

## Test plan

- [x] `examples/bridge-demo` builds; generated `App.swift` shows the new order
- [x] A test app that seeds `isLoggedIn = new State<Bool>(true, "isLoggedIn")` in its constructor now boots to the authenticated branch instead of falling through to the login view
- [x] Existing examples (hello-world, todo-app, counter, navigation) still build — none of them rely on the previous "init wipes pushed values" misbehaviour

## Note

This makes the `bootstrap()`-style workaround that some apps adopted to manually re-push state from a taskAction after view appear (calendar-mac being one of them) redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)