### PR TITLE
Add .keyboardShortcut(key, modifiers) modifier

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -162,6 +162,57 @@ new Text("Hold me")
     .onLongPressGesture(showMenu.tog())
 ```
 
+## Keyboard
+
+| Modifier | Parameters | Description |
+|----------|-----------|-------------|
+| `.keyboardShortcut(key, modifiers)` | `key: String`, `modifiers: Array<String>` (optional) | Bind a keyboard shortcut to a view (typically a Button). Maps to SwiftUI's `.keyboardShortcut(_:, modifiers:)`. |
+
+**`key`** is either a single character (`"n"`, `"s"`, `","`) or one of the named special keys:
+
+| Name | Swift `KeyEquivalent` |
+|------|-----------------------|
+| `"return"` | `.return` |
+| `"escape"` | `.escape` |
+| `"delete"` / `"backspace"` | `.delete` |
+| `"tab"` | `.tab` |
+| `"space"` | `.space` |
+| `"left"` | `.leftArrow` |
+| `"right"` | `.rightArrow` |
+| `"up"` | `.upArrow` |
+| `"down"` | `.downArrow` |
+| `"home"` / `"end"` | `.home` / `.end` |
+| `"pageup"` / `"pagedown"` | `.pageUp` / `.pageDown` |
+
+**`modifiers`** is any combination (order doesn't matter) of:
+
+| Name | Swift `EventModifiers` |
+|------|------------------------|
+| `"command"` / `"cmd"` | `.command` |
+| `"option"` / `"alt"` | `.option` |
+| `"control"` / `"ctrl"` | `.control` |
+| `"shift"` | `.shift` |
+| `"capslock"` | `.capsLock` |
+
+Omitting `modifiers` (or passing an empty array) binds the bare key — useful for `"escape"`, arrow keys, etc.
+
+```haxe
+new Button("New Event", null, openNewEventAction)
+    .keyboardShortcut("n", ["command"]);          // ⌘N
+
+new Button("Today", null, showTodayAction)
+    .keyboardShortcut("t", ["command"]);          // ⌘T
+
+new Button("Close", null, dismissAction)
+    .keyboardShortcut("escape");                  // Esc
+
+new Button("Next", null, nextAction)
+    .keyboardShortcut("right", ["command"]);      // ⌘→
+
+new Button("Save As…", null, saveAsAction)
+    .keyboardShortcut("s", ["command", "shift"]); // ⇧⌘S
+```
+
 ## Lifecycle
 
 | Modifier | Parameters | Description |

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -290,6 +290,31 @@ class View {
         return this;
     }
 
+    /** Bind a keyboard shortcut to this view (typically a Button) —
+        maps to SwiftUI's `.keyboardShortcut(_:, modifiers:)`.
+
+        `key` accepts a single character (`"n"`, `"s"`, `","`) or one
+        of the named special keys: `"return"`, `"escape"`, `"delete"`,
+        `"tab"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`.
+
+        `modifiers` is any combination of `"command"`, `"option"`,
+        `"control"`, `"shift"`. Order doesn't matter; an empty array
+        means the bare key (rare; mostly used for `escape` and arrow
+        keys).
+
+        ```haxe
+        new Button("New Event", null, openNewEventAction)
+            .keyboardShortcut("n", ["command"]);
+
+        new Button("Today", null, showTodayAction)
+            .keyboardShortcut("t", ["command"]);
+        ```
+    **/
+    public function keyboardShortcut(key:String, ?modifiers:Array<String>):View {
+        modifierChain.push(ViewModifier.KeyboardShortcut(key, modifiers != null ? modifiers : []));
+        return this;
+    }
+
     /** Run a StateAction when the view appears. **/
     public function onAppearAction(action:sui.state.StateAction):View {
         modifierChain.push(ViewModifier.OnAppearAction(action));

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1810,7 +1810,8 @@ class SwiftGenerator {
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" |
-                 "onSubmit" | "onLongPressGesture" | "transition":
+                 "onSubmit" | "onLongPressGesture" | "transition" |
+                 "keyboardShortcut":
                 true;
             default: false;
         }
@@ -2049,6 +2050,35 @@ class SwiftGenerator {
                     'onLongPressGesture { ${actionCode} }';
                 else
                     'onLongPressGesture { }';
+            case "keyboardShortcut":
+                // args[0]: key string. args[1]: modifiers Array<String>.
+                // Emits `.keyboardShortcut(KeyEquivalent("k"), modifiers: [.command, ...])`
+                // — the named-key sentinels resolve to `.return`, `.escape`,
+                // `.delete`, `.tab`, `.space`, `.leftArrow`, `.rightArrow`,
+                // `.upArrow`, `.downArrow`; everything else maps directly to
+                // `KeyEquivalent("<char>")`.
+                var key = if (args.length > 0) extractString(args[0]) else null;
+                if (key == null) key = "";
+                var keyExpr = keyEquivalentToSwift(key);
+                var mods:Array<String> = [];
+                if (args.length > 1) {
+                    var arrE = unwrap(args[1]);
+                    switch (arrE.expr) {
+                        case TArrayDecl(elems):
+                            for (el in elems) {
+                                var s = extractString(el);
+                                if (s != null) {
+                                    var swift = modifierKeyToSwift(s);
+                                    if (swift != null) mods.push(swift);
+                                }
+                            }
+                        default:
+                    }
+                }
+                if (mods.length > 0)
+                    'keyboardShortcut(${keyExpr}, modifiers: [${mods.join(", ")}])';
+                else
+                    'keyboardShortcut(${keyExpr})';
 
             default:
                 // Generic: try to pass through args
@@ -2235,6 +2265,41 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Map a sui `keyboardShortcut` key string to the matching
+        SwiftUI `KeyEquivalent`. Named keys (return, escape, …)
+        resolve to their static properties; anything else is wrapped
+        in `KeyEquivalent("<char>")`. **/
+    static function keyEquivalentToSwift(key:String):String {
+        return switch (key.toLowerCase()) {
+            case "return": ".return";
+            case "escape": ".escape";
+            case "delete" | "backspace": ".delete";
+            case "tab": ".tab";
+            case "space": ".space";
+            case "left": ".leftArrow";
+            case "right": ".rightArrow";
+            case "up": ".upArrow";
+            case "down": ".downArrow";
+            case "home": ".home";
+            case "end": ".end";
+            case "pageup": ".pageUp";
+            case "pagedown": ".pageDown";
+            default: 'KeyEquivalent("${esc(key)}")';
+        };
+    }
+
+    /** Map a sui modifier-key name to its `EventModifiers` member. **/
+    static function modifierKeyToSwift(name:String):Null<String> {
+        return switch (name.toLowerCase()) {
+            case "command" | "cmd": ".command";
+            case "option" | "alt": ".option";
+            case "control" | "ctrl": ".control";
+            case "shift": ".shift";
+            case "capslock": ".capsLock";
+            default: null;
+        };
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -100,6 +100,13 @@ enum ViewModifier {
     // Interaction
     OnSubmit(actionId:Int);
     OnLongPressGesture(action:sui.state.StateAction);
+    /** SwiftUI `.keyboardShortcut(_:, modifiers:)` — binds a keyboard
+        shortcut to the receiving view (typically a Button). The
+        `key` is a single character or one of the special-name
+        sentinels: "return", "escape", "delete", "tab", "space",
+        "left", "right", "up", "down". `modifiers` is any
+        combination of "command" / "option" / "control" / "shift". **/
+    KeyboardShortcut(key:String, modifiers:Array<String>);
 
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);


### PR DESCRIPTION
## Summary

Adds a SwiftUI keyboard shortcut binding to sui's View modifier chain.

```haxe
new Button("New", null, openAction)
    .keyboardShortcut("n", ["command"]);          // ⌘N

new Button("Close", null, dismissAction)
    .keyboardShortcut("escape");                  // Esc

new Button("Save As…", null, saveAsAction)
    .keyboardShortcut("s", ["command", "shift"]); // ⇧⌘S
```

## Wiring

- `View.keyboardShortcut(key:String, ?modifiers:Array<String>)` — public API.
- `ViewModifier.KeyboardShortcut(key, modifiers)` enum variant.
- Macro `case "keyboardShortcut"` resolves the key string through a new `keyEquivalentToSwift` helper (special-cases `return`, `escape`, `delete`, `tab`, `space`, `left`/`right`/`up`/`down`, `home`, `end`, `pageup`, `pagedown`; falls through to `KeyEquivalent("<char>")`) and each modifier name through `modifierKeyToSwift` (`command`, `option`, `control`, `shift`, `capslock`, plus `cmd` / `alt` / `ctrl` aliases).

Emits:

```swift
Button("New") { … }
    .keyboardShortcut(KeyEquivalent("n"), modifiers: [.command])

Button("Close") { … }
    .keyboardShortcut(.escape)

Button("Next") { … }
    .keyboardShortcut(.rightArrow, modifiers: [.command])
```

## Test plan

- [x] `examples/counter` still builds and the generated Swift is unchanged for buttons without `.keyboardShortcut`
- [x] A scratch app exercising `n` / `t` / `escape` / `right` keys plus all the modifier combinations emits the expected Swift
- [x] No regression on the modifier dispatch (`isModifier` extended, all existing cases unchanged)

## Docs

`docs/modifiers.md` gains a "Keyboard" section right after "Gestures" with the key/modifier name tables and a handful of examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)