### PR TITLE
Add Menu view — drop-down menu of buttons / nested menus

### DIFF
--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,28 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## Menu
+
+A drop-down menu containing buttons or nested `Menu`s. Maps to SwiftUI's `Menu`. The typical use case is a toolbar dropdown — clicking the label opens a popover with the actions. On macOS it adopts the system `NSMenu` look; on iOS it's a popover sheet.
+
+```haxe
+new Menu("Actions", [
+    new Button("New", null, newAction),
+    new Button("Open…", null, openAction),
+    new Menu("Recent", [
+        new Button("File 1", null, openFile1Action),
+        new Button("File 2", null, openFile2Action),
+    ]),
+    new Button("Delete", null, deleteAction),
+])
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | `String` | The text shown on the menu trigger |
+| `content` | `Array<View>` | The menu items — typically `Button`s or nested `Menu`s |
+
+Menus can be nested arbitrarily for sub-menus.

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1362,6 +1362,26 @@ class SwiftGenerator {
                 buf.add('${pad}}\n');
                 return buf.toString();
 
+            case "Menu":
+                // First arg is the label (String), second is a
+                // TArrayDecl of child views (typically Buttons or
+                // nested Menus).
+                var label = if (args.length > 0) extractString(args[0]) else null;
+                var children:Array<haxe.macro.Type.TypedExpr> = [];
+                if (args.length > 1) {
+                    var uArg = unwrap(args[1]);
+                    switch (uArg.expr) {
+                        case TArrayDecl(el): children = el;
+                        default:
+                    }
+                }
+                var buf = new StringBuf();
+                buf.add('${pad}Menu("${esc(label != null ? label : "")}") {\n');
+                for (child in children)
+                    buf.add(viewToSwift(child, indent + 1));
+                buf.add('${pad}}\n');
+                return buf.toString();
+
             case "AdaptiveStack":
                 needsHorizontalSizeClass = true;
                 var buf = new StringBuf();

--- a/src/sui/ui/Menu.hx
+++ b/src/sui/ui/Menu.hx
@@ -1,0 +1,33 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A drop-down menu containing buttons (or nested menus / dividers).
+    Maps to SwiftUI's `Menu`.
+
+    The typical use case is a toolbar dropdown — clicking the label
+    opens a popover with the actions. On macOS it adopts the system
+    `NSMenu` look; on iOS it's a popover sheet.
+
+    ```haxe
+    new Menu("Actions", [
+        new Button("New", null, newAction),
+        new Button("Open…", null, openAction),
+        new Button("Delete", null, deleteAction),
+    ])
+    ```
+
+    `Menu`s can be nested for sub-menus.
+**/
+@:swiftView("Menu")
+class Menu extends View {
+    public var label:String;
+
+    public function new(@:swiftLabel("_") label:String, content:Array<View>) {
+        super();
+        this.viewType = "Menu";
+        this.label = label;
+        this.children = content;
+    }
+}


### PR DESCRIPTION
## Summary

`new Menu(label, content)` is a sui view that compiles to SwiftUI's `Menu(label) { … }` — the native macOS NSMenu popover (iOS: popover sheet) used to hide a set of related actions behind one toolbar item or label.

```haxe
new Menu("Actions", [
    new Button("New", null, newAction),
    new Button("Open…", null, openAction),
    new Menu("Recent", [
        new Button("File 1", null, openFile1Action),
        new Button("File 2", null, openFile2Action),
    ]),
    new Button("Delete", null, deleteAction),
])
```

Emits:

```swift
Menu("Actions") {
    Button("New") { … }
    Button("Open…") { … }
    Menu("Recent") {
        Button("File 1") { … }
        Button("File 2") { … }
    }
    Button("Delete") { … }
}
```

## Wiring

- `sui/ui/Menu.hx` — `@:swiftView("Menu")` View subclass with `(label:String, content:Array<View>)` constructor.
- SwiftGenerator's `case "Menu"` follows the Section pattern: extract the label, the `TArrayDecl` of children, then emit `Menu("…") { children }`. Nested Menus recurse through `viewToSwift` for free.

## Test plan

- [x] A small scratch app with a top-level `Menu` plus a nested `Menu` emits the expected nested Swift.
- [x] Existing examples keep building (no regression — `case "Menu"` is a new branch).

## Docs

`docs/views/controls.md` gains a Menu section right after Picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)