### PR TITLE
Add CommandMenu — top-level macOS menu-bar menus

### DIFF
--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,51 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## CommandMenu (macOS menu bar)
+
+A top-level menu in the macOS menu bar — appears next to **File / Edit / View / Help**. Maps to SwiftUI's `CommandMenu`. iOS, iPadOS and tvOS don't show a menu bar, so `CommandMenu`s are dropped at runtime on those platforms.
+
+CommandMenus are declared by overriding `commands()` on your `App` subclass — *not* by including them in `body()`. The macro reads the `commands()` method at compile time and emits a `.commands { … }` modifier on the App's WindowGroup.
+
+```haxe
+class MyApp extends sui.App {
+    public function new() {
+        super();
+        appName = "MyApp";
+        bundleIdentifier = "com.example.myapp";
+    }
+
+    override function body():View {
+        return new Text("Hello");
+    }
+
+    override function commands():Array<CommandMenu> {
+        return [
+            new CommandMenu("Calendar", [
+                new Button("New Event", null, newEventAction)
+                    .keyboardShortcut("n", ["command"]),
+                new Button("Today", null, showTodayAction)
+                    .keyboardShortcut("t", ["command"]),
+            ]),
+            new CommandMenu("View", [
+                new Button("Month", null, showMonthAction)
+                    .keyboardShortcut("1", ["command"]),
+                new Button("Week", null, showWeekAction)
+                    .keyboardShortcut("2", ["command"]),
+                new Button("Day", null, showDayAction)
+                    .keyboardShortcut("3", ["command"]),
+            ]),
+        ];
+    }
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | `String` | Menu title in the menu bar |
+| `content` | `Array<View>` | Buttons (typically with `.keyboardShortcut`) — these become menu items |
+
+Pair `CommandMenu`s with `.keyboardShortcut(...)` on each Button to expose the same shortcut both as a menu item and as a global ⌘ shortcut. See the [Keyboard modifier section](../modifiers.md#keyboard).

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,20 @@ class App {
         return new View();
     }
 
+    /** Override to attach top-level menus to the macOS menu bar. The
+        returned array is read at compile time by the SwiftGenerator
+        macro and emitted as a `.commands { CommandMenu(…) { … } … }`
+        modifier on the App's WindowGroup. iOS / iPadOS / tvOS
+        ignore the commands at runtime (the menu bar isn't shown).
+
+        Each item inside a `CommandMenu` is typically a `Button` with
+        a `.keyboardShortcut`. See `sui.ui.CommandMenu` for a full
+        example.
+    **/
+    public function commands():Array<sui.ui.CommandMenu> {
+        return [];
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,12 +150,19 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var commandsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "commands") {
+                // Walk `commands()` to find its returned TArrayDecl of
+                // `new CommandMenu(...)` values. Render each via
+                // `viewToSwift` and stitch them into a single
+                // `.commands { … }` block attached to WindowGroup.
+                var expr = field.expr();
+                if (expr != null) commandsSwift = walkCommandsFunc(expr);
             }
         }
 
@@ -174,6 +181,11 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (commandsSwift != "") {
+            appSwift.add("        .commands {\n");
+            appSwift.add(commandsSwift);
+            appSwift.add("        }\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -864,6 +876,72 @@ class SwiftGenerator {
         }
     }
 
+    /** Walk `commands(): Array<CommandMenu>` — find the returned
+        TArrayDecl, render each element via `viewToSwift`, and join
+        with the right indentation for the `.commands { … }` block
+        on the App's WindowGroup.
+
+        Haxe's typer hoists complex sub-expressions into TVar
+        bindings (e.g. inner `new Button(...)` references become
+        TLocal pointing at synthesised vars). `viewToSwift` resolves
+        TLocal through `localBindings`, so we walk the function body
+        ahead of time and collect every TVar's init expression
+        into that map. Without this pass the TLocal refs bubble up
+        as `// [sui] unhandled expression: TLocal` placeholders. **/
+    static function walkCommandsFunc(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "";
+        function collectBindings(e:haxe.macro.Type.TypedExpr):Void {
+            if (e == null) return;
+            switch (e.expr) {
+                case TVar(v, initExpr):
+                    if (initExpr != null) {
+                        localBindings.set(v.id, initExpr);
+                        collectBindings(initExpr);
+                    }
+                case TFunction(f): collectBindings(f.expr);
+                case TBlock(stmts):
+                    for (s in stmts) collectBindings(s);
+                case TReturn(re): collectBindings(re);
+                case TCast(inner, _): collectBindings(inner);
+                case TParenthesis(inner): collectBindings(inner);
+                case TMeta(_, inner): collectBindings(inner);
+                case TArrayDecl(elems):
+                    for (el in elems) collectBindings(el);
+                case TNew(_, _, args):
+                    for (a in args) collectBindings(a);
+                case TCall(_, args):
+                    for (a in args) collectBindings(a);
+                case TArray(arr, idx):
+                    collectBindings(arr);
+                    collectBindings(idx);
+                default:
+            }
+        }
+        collectBindings(expr);
+
+        // Descend through TFunction / TBlock / TReturn to the TArrayDecl.
+        function findArrayDecl(e:haxe.macro.Type.TypedExpr):Null<Array<haxe.macro.Type.TypedExpr>> {
+            if (e == null) return null;
+            switch (e.expr) {
+                case TFunction(f): return findArrayDecl(f.expr);
+                case TBlock(stmts):
+                    if (stmts.length > 0) return findArrayDecl(stmts[stmts.length - 1]);
+                case TReturn(re): return findArrayDecl(re);
+                case TCast(inner, _): return findArrayDecl(inner);
+                case TParenthesis(inner): return findArrayDecl(inner);
+                case TMeta(_, inner): return findArrayDecl(inner);
+                case TArrayDecl(elems): return elems;
+                default:
+            }
+            return null;
+        }
+        var elems = findArrayDecl(expr);
+        if (elems == null || elems.length == 0) return "";
+        var buf = new StringBuf();
+        for (cm in elems) buf.add(viewToSwift(cm, 3));
+        return buf.toString();
+    }
+
     static function viewToSwift(expr:haxe.macro.Type.TypedExpr, indent:Int):String {
         // Unwrap casts, metas, parentheses
         var unwrapped = unwrap(expr);
@@ -1357,6 +1435,27 @@ class SwiftGenerator {
                     buf.add('${pad}Section("${esc(header)}") {\n');
                 else
                     buf.add('${pad}Section {\n');
+                for (child in children)
+                    buf.add(viewToSwift(child, indent + 1));
+                buf.add('${pad}}\n');
+                return buf.toString();
+
+            case "CommandMenu":
+                // Top-level macOS menu-bar menu. Same shape as
+                // `Section` / `Menu`: label string + TArrayDecl of
+                // children. Attached to the App scene by the App.swift
+                // emitter via `.commands { … }`.
+                var label = if (args.length > 0) extractString(args[0]) else null;
+                var children:Array<haxe.macro.Type.TypedExpr> = [];
+                if (args.length > 1) {
+                    var uArg = unwrap(args[1]);
+                    switch (uArg.expr) {
+                        case TArrayDecl(el): children = el;
+                        default:
+                    }
+                }
+                var buf = new StringBuf();
+                buf.add('${pad}CommandMenu("${esc(label != null ? label : "")}") {\n');
                 for (child in children)
                     buf.add(viewToSwift(child, indent + 1));
                 buf.add('${pad}}\n');

--- a/src/sui/ui/CommandMenu.hx
+++ b/src/sui/ui/CommandMenu.hx
@@ -1,0 +1,43 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A top-level macOS menu-bar menu — appears next to File / Edit / View
+    / Help in the system menu bar. Maps to SwiftUI's `CommandMenu` and
+    is attached to the App scene via the `commands()` override.
+
+    Items are typically `Button`s (with `.keyboardShortcut(...)` so each
+    has an associated ⌘-shortcut) and `Divider`s between groups.
+    Nested `Menu`s aren't supported by `CommandMenu` directly — use
+    sub-`CommandMenu`s instead.
+
+    ```haxe
+    class MyApp extends sui.App {
+        override function commands():Array<CommandMenu> {
+            return [
+                new CommandMenu("Calendar", [
+                    new Button("New Event", null, newEventAction)
+                        .keyboardShortcut("n", ["command"]),
+                    new Button("Today", null, showTodayAction)
+                        .keyboardShortcut("t", ["command"]),
+                ]),
+            ];
+        }
+    }
+    ```
+
+    On iOS / iPadOS / tvOS the menu bar isn't shown, so `CommandMenu`s
+    are silently dropped by SwiftUI on those platforms.
+**/
+@:swiftView("CommandMenu")
+class CommandMenu extends View {
+    public var label:String;
+
+    public function new(@:swiftLabel("_") label:String, content:Array<View>) {
+        super();
+        this.viewType = "CommandMenu";
+        this.label = label;
+        this.children = content;
+    }
+}


### PR DESCRIPTION
## Summary

`CommandMenu` is a new sui view + an `App.commands()` override that together let users add top-level menus to the macOS menu bar — the standard pattern for File / Edit / View / custom items next to them.

```haxe
class MyApp extends sui.App {
    override function body():View { return new Text("…"); }

    override function commands():Array<CommandMenu> {
        return [
            new CommandMenu("Calendar", [
                new Button("New Event", null, newEventAction)
                    .keyboardShortcut("n", ["command"]),
                new Button("Today", null, showTodayAction)
                    .keyboardShortcut("t", ["command"]),
            ]),
        ];
    }
}
```

Emits:

```swift
WindowGroup("MyApp") { ContentView() }
    .commands {
        CommandMenu("Calendar") {
            Button("New Event") { … }
                .keyboardShortcut(KeyEquivalent("n"), modifiers: [.command])
            Button("Today") { … }
                .keyboardShortcut(KeyEquivalent("t"), modifiers: [.command])
        }
    }
```

SwiftUI places each CommandMenu in the macOS menu bar at runtime. iOS / iPadOS / tvOS don't show a menu bar, so the `.commands { … }` block is dropped on those platforms.

## Wiring

- `sui/ui/CommandMenu.hx` — `@:swiftView("CommandMenu")` View subclass with the now-standard `(label:String, content:Array<View>)` constructor.
- `sui/App.hx` gains `commands():Array<CommandMenu>` (defaults to `[]`).
- `SwiftGenerator` finds the `commands` method on the App class (mirroring how `body` is discovered), then `walkCommandsFunc`:
  1. **Collects every nested `TVar` init expression** into `localBindings` — Haxe's typer hoists the inner `new Button(…)` constructors into temp vars, so the final `TArrayDecl` contains `TLocal` refs that need to resolve. Without this pass the generated Swift was full of `// [sui] unhandled expression: TLocal` placeholders.
  2. **Finds the returned `TArrayDecl`** and renders each `CommandMenu` via `viewToSwift`. All the usual modifier chains (notably `.keyboardShortcut`) work transparently.
- `case "CommandMenu"` in `newToSwift` follows the Section / Menu pattern: emit `CommandMenu("…") { children }`.

## Test plan

- [x] A scratch app with two `CommandMenu`s × multiple buttons emits the expected nested `.commands { … }` block; `App.swift` is well-formed Swift.
- [x] An app that doesn't override `commands()` produces no `.commands` modifier — no behaviour change for existing examples.

## Pair with

This PR composes well with [#66 `keyboardShortcut`](https://github.com/Pign/sui/pull/66) — each menu-bar item typically gets a ⌘-shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)