### PR TITLE
Add Settings scene — macOS Preferences window

### DIFF
--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,32 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## Settings (Preferences window)
+
+A separate macOS Preferences window — opened with **⌘,** or the system **App ▸ Preferences…** menu. Declared by overriding `settings()` on your `App` subclass. The returned view is rendered into its own SwiftUI `Settings` scene, alongside the main `WindowGroup`. If you don't override `settings()`, no Settings scene is emitted.
+
+```haxe
+class MyApp extends sui.App {
+    @:state var darkMode:Bool = false;
+    @:state var userName:String = "";
+
+    override function body():View {
+        return new VStack([
+            new Text("Main window"),
+            Text.withState("Dark mode: {darkMode}"),
+        ]);
+    }
+
+    override function settings():View {
+        return new Form([
+            new Toggle("Dark Mode", "darkMode"),
+            new TextField("Display name", "userName"),
+        ]);
+    }
+}
+```
+
+The Settings view shares state with the main `body()` automatically — toggles in Preferences immediately update the main window and vice versa. The macro emits a `SettingsView` Swift struct alongside `ContentView`, both bound to the same `AppState.shared` singleton.
+
+iOS, iPadOS and tvOS ignore the Settings scene at runtime (those platforms route preferences through the system Settings app or an in-app view), so the generated `Settings { … }` block is wrapped in `#if os(macOS)`.

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,28 @@ class App {
         return new View();
     }
 
+    /** Override to declare a Settings (Preferences) window — the
+        standard macOS `App ▸ Preferences…` / ⌘, scene. The returned
+        view is rendered into its own SwiftUI `Settings` scene
+        alongside the main WindowGroup; if this is left at the
+        default (a bare `View()`), no Settings scene is emitted.
+
+        ```haxe
+        override function settings():View {
+            return new Form([
+                new Toggle("Dark Mode", "darkMode"),
+                new Picker("Default View", "defaultView", [...]),
+            ]);
+        }
+        ```
+
+        iOS / iPadOS / tvOS ignore the Settings scene at runtime —
+        on those platforms preferences belong in the system Settings
+        bundle or an in-app view. **/
+    public function settings():View {
+        return new View();
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,14 +150,29 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var settingsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "settings") {
+                var expr = field.expr();
+                if (expr != null) settingsSwift = walkFunc(expr, 2);
             }
         }
+        // The default `settings()` returns `new View()`, which
+        // `viewToSwift` renders as a "Unknown view" placeholder
+        // comment. Treat that as "user didn't override" and skip
+        // emitting the Settings scene altogether.
+        var hasSettings = settingsSwift != "" && settingsSwift.indexOf("Unknown view") == -1;
+        // The Settings scene only makes sense if its preferences
+        // share state with the rest of the app — `Toggle("Dark Mode",
+        // "darkMode")` in Settings must read/write the same value
+        // ContentView observes. Force the bridged AppState path so
+        // both view structs reference `AppState.shared` rather than
+        // each carrying its own private `@State` copies.
+        if (hasSettings) needsRuntimeBridge = true;
 
         // 5. Emit App.swift (after needsRuntimeBridge is finalized)
         var appSwift = new StringBuf();
@@ -174,6 +189,13 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (hasSettings) {
+            appSwift.add("        #if os(macOS)\n");
+            appSwift.add("        Settings {\n");
+            appSwift.add("            SettingsView()\n");
+            appSwift.add("        }\n");
+            appSwift.add("        #endif\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -228,6 +250,42 @@ class SwiftGenerator {
 
         viewSwift.add("    }\n");
         viewSwift.add("}\n");
+
+        // 5b. Optionally emit a SettingsView struct alongside ContentView.
+        //     Same `@Bindable var appState` (or `@State`s) wiring so it
+        //     can read/write the same app-wide state.
+        if (hasSettings) {
+            viewSwift.add("\n");
+            viewSwift.add("struct SettingsView: View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                viewSwift.add("    @Bindable var appState = AppState.shared\n\n");
+            } else {
+                for (sd in stateDecls)
+                    viewSwift.add('    @State private var ${sd.name}: ${sd.swiftType} = ${sd.defaultValue}\n');
+                if (stateDecls.length > 0) viewSwift.add("\n");
+            }
+            viewSwift.add("    var body: some View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                // Reuse the same appState-prefix pass as ContentView.
+                var s = settingsSwift;
+                var placeholder = "__APPSTATE__";
+                for (sd in stateDecls) {
+                    var n = sd.name;
+                    s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
+                    s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
+                    s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
+                    s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
+                }
+                s = StringTools.replace(s, placeholder, "appState.");
+                viewSwift.add(s);
+            } else {
+                viewSwift.add(settingsSwift);
+            }
+            viewSwift.add("    }\n");
+            viewSwift.add("}\n");
+        }
 
         // 6. Generate model structs for Observable subclasses used by this app
         var modelSwift = new StringBuf();


### PR DESCRIPTION
## Summary

Adds a `settings()` override on `sui.App` that the macro reads at compile time to emit a SwiftUI `Settings { SettingsView() }` scene alongside the main `WindowGroup`. The resulting Preferences window opens with ⌘, on macOS — the standard pattern for any non-trivial Mac app.

```haxe
class MyApp extends sui.App {
    @:state var darkMode:Bool = false;
    @:state var userName:String = "";

    override function body():View {
        return new VStack([
            new Text("Main"),
            Text.withState("Dark: {darkMode}"),
        ]);
    }

    override function settings():View {
        return new Form([
            new Toggle("Dark Mode", "darkMode"),
            new TextField("Display name", "userName"),
        ]);
    }
}
```

Emits a second view struct alongside `ContentView`:

```swift
struct SettingsView: View {
    @Bindable var appState = AppState.shared
    var body: some View {
        Form {
            Toggle("Dark Mode", isOn: $appState.darkMode)
            TextField("Display name", text: $appState.userName)
        }
    }
}
```

…and a Settings scene in App.swift:

```swift
WindowGroup("MyApp") { ContentView() }
#if os(macOS)
Settings { SettingsView() }
#endif
```

## Shared state

Both view structs bind to the same `AppState.shared` singleton — toggles in Preferences immediately reflect in the main window without any extra wiring. To make sure the singleton always exists, overriding `settings()` forces the bridged-AppState path (`needsRuntimeBridge = true`). Apps that previously used inline `@State` will switch to the AppState pattern when they adopt Settings, which is also the canonical SwiftUI way to share preferences across scenes.

## Wiring

- `sui/App.hx` gains a `settings():View` override (defaults to a bare `View()` placeholder).
- SwiftGenerator scans the App's fields for `settings` (mirroring how `body` is discovered) and walks it through `walkFunc`. If the result is the unmodified placeholder (`// Unknown view: View`), the Settings scene is skipped — apps that don't override pay nothing.
- A new `SettingsView` Swift struct is emitted right after `ContentView`, sharing the same `@Bindable var appState` wiring and the same appState-prefix pass.
- App.swift's body now conditionally appends a `#if os(macOS) Settings { SettingsView() } #endif` block to the scene list.

## Test plan

- [x] A scratch app with `@:state var darkMode:Bool` and `settings()` returning a Form with a Toggle emits the expected SettingsView + Settings scene; toggling darkMode in Preferences updates the main window's state.
- [x] An app that doesn't override `settings()` produces no Settings scene and no SettingsView struct — no behaviour change for existing apps.
- [x] App.swift's `#if os(macOS)` guard prevents iOS/iPadOS/tvOS builds from referencing the macOS-only Settings scene type.

## Pair with

This rounds out Tier 1 of the macOS-chrome additions — alongside [#66 keyboardShortcut](https://github.com/Pign/sui/pull/66), [#67 Menu](https://github.com/Pign/sui/pull/67), and [#68 CommandMenu](https://github.com/Pign/sui/pull/68) — an app can now expose its main features through a menu-bar `CommandMenu`, ⌘-shortcuts, and a Preferences window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)