### PR TITLE
Docs catchup: fill modifiers, foregroundHex, buttonStyle, pickerStyle, onChange, ForEach closure form, bridge safety

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -195,6 +195,32 @@ class BridgeApp extends App {
 }
 ```
 
+## Initial Values Reach Swift
+
+When you construct a `State<T>` in your App's constructor with a non-default value — typically because the value comes from a stored token, a config file, or a computed boot-time check — that initial value is pushed across the bridge to SwiftUI's `AppState` automatically:
+
+```haxe
+public function new() {
+    super();
+    var stored = Tokens.load();
+    var logged = stored != null && !stored.isExpired();
+    isLoggedIn = new State<Bool>(logged, "isLoggedIn"); // ← Swift sees `logged`
+}
+```
+
+The first body render observes the constructor-side value, so a `ConditionalView(isLoggedIn, …)` boots into the right branch on launch — no manual "bootstrap" taskAction needed.
+
+This was historically a foot-gun: the swift-side state callback was registered *after* `haxe_bridge_init` ran, so anything the constructor pushed hit a null callback and was dropped. The fix lives in two coordinated changes: the generated `App.swift` registers the callback *before* `HaxeRuntime.initialize()`, and `State<T>`'s constructor itself fires `_hxsui_notify_swift` with the initial value (arrays send the empty-string sentinel that bumps the version counter).
+
+## Thread Safety
+
+Every entry into `HaxeBridgeC` — both your `@:expose` user functions and the implicit shared-memory readers (`arrayLength`, `arrayStringElement`, `objectField`, …) — is serialised through a single `std::recursive_mutex` and wrapped in a top-level `try/catch (::Dynamic)`. Two consequences for client code:
+
+1. **`Task.detached` is safe to combine with SwiftUI computed properties.** A closure-form `ForEach` may issue `arrayLength` / `arrayStringElement` calls from the main thread while a `Task.detached` user function is running Haxe code on a cooperative-pool thread; the mutex stops them from racing the hxcpp GC. (Until this landed, you'd see random `EXC_BAD_ACCESS` crashes inside innocuous-looking `String` operations.)
+2. **An uncaught Haxe `throw` is logged, not fatal.** The bridge body catches `Dynamic` exceptions and any `std::exception` / `...` fallback, writes a `[sui] <bridge>: Haxe exception` line to stderr, and returns the function's typed default (`0`, `false`, `""`, void). The Swift side observes the default value instead of a process termination, so a bridge function that throws on a network error or a malformed input is a recoverable condition — not an `abort()`.
+
+Recoverable doesn't mean silent: your `@:expose` body should still `try { … } catch (e:Dynamic) { return 'Erreur: $e'; }` if the caller wants a descriptive message back, since the bridge's safety-net catch just logs and returns a default.
+
 ## Multi-State Updates with State.setByName
 
 When a bridge function needs to update multiple `@:state` variables, use `State.setByName()` from a closure:

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -17,11 +17,17 @@ new Text("Styled")
 | `.padding()` | none | Default system padding |
 | `.padding(value)` | `value: Float` | Fixed padding on all edges |
 | `.frame(width, height, alignment)` | `width: Float`, `height: Float`, `alignment: Alignment` | All optional. Sets size constraints |
+| `.fillWidth()` | none | Equivalent to `.frame(maxWidth: .infinity)` — stretches the view across its container's full width. |
+| `.fillHeight()` | none | `.frame(maxHeight: .infinity)` |
+| `.fillBoth()` | none | `.frame(maxWidth: .infinity, maxHeight: .infinity)` |
+| `.fixedSize(horizontal, vertical)` | `horizontal: Bool` (default `false`), `vertical: Bool` (default `true`) | Prevent the view from being shrunk on the given axes. Useful when a `Text` or `List` collapses to zero inside a flexible parent. |
 | `.overlay(content)` | `content: View` | Overlays another view on top |
 | `.aspectRatio(ratio, contentMode)` | `ratio: Float`, `contentMode: String` | Constrain proportions (`"fit"` or `"fill"`) |
 | `.offset(x, y)` | `x: Dynamic`, `y: Dynamic` | Offset view position (Float or state name) |
 
 **Alignment values:** `Center`, `Leading`, `Trailing`, `Top`, `Bottom`, `TopLeading`, `TopTrailing`, `BottomLeading`, `BottomTrailing`
+
+The `fill*` helpers exist because `.frame(maxWidth: .infinity)` is by far the most common workaround for SwiftUI containers — `List` inside a `.sheet`, cells inside a `LazyVGrid` — that collapse to their content's intrinsic width without an explicit stretch.
 
 ## Typography
 
@@ -58,6 +64,8 @@ new Text("Styled")
 | `.background(color)` | `color: ColorValue` | Background color |
 | `.opacity(value)` | `value: Float` | Opacity (0.0 to 1.0) |
 | `.tint(color)` | `color: ColorValue` | Accent/tint color |
+| `.foregroundHex(expr)` | `expr: Dynamic` | Foreground colour from a runtime hex string. See below for the accepted shapes. |
+| `.backgroundHex(expr)` | `expr: Dynamic` | Same as `foregroundHex` but for the background fill. |
 
 **ColorValue values:** `Primary`, `Secondary`, `Accent`, `Red`, `Orange`, `Yellow`, `Green`, `Blue`, `Purple`, `Pink`, `White`, `Black`, `Gray`, `Clear`, `Custom(hex)`
 
@@ -65,6 +73,41 @@ new Text("Styled")
 new Text("Custom color")
     .foregroundColor(ColorValue.Custom("#EA8220"))
 ```
+
+### `foregroundHex` / `backgroundHex`
+
+For colours that come from a `@State` value at runtime (per-row tinting in a `ForEach`, theme switches, server-supplied colours, …) the `ColorValue` enum is too rigid. The `*Hex` variants accept a runtime expression and parse it through `Color(suiHex:)`. Invalid or empty strings fall through to `Color.primary` / `Color.clear` via the nil-coalescing operator, so it's safe to pass `""` to mean "default".
+
+Three shapes are recognised:
+
+1. **String literal** — embedded verbatim into the generated Swift, then run through the body's appState-prefix pass. Useful for the legacy `"name"` / `"name[i]"` patterns.
+
+   ```haxe
+   new Text("●").foregroundHex("calendarColor");
+   new Text("●").foregroundHex("calendarColors[i]");
+   ```
+
+2. **Typed `State<String>` field reference** — no `.value`, no string, no quoting:
+
+   ```haxe
+   @:state var tint:String = "#EA8220";
+
+   new Text("•").foregroundHex(tint);   // → appState.tint
+   ```
+
+3. **Closure-form ForEach item ref** — inside a `new ForEach(arr, item -> …)` lambda, pass the iteration parameter (or a parallel-array subscript) directly:
+
+   ```haxe
+   new ForEach(colors, color ->
+       new Text("•").foregroundHex(color)
+   )
+
+   new ForEach(indices, i ->
+       new Text("•").foregroundHex(rowColors.value[i])
+   )
+   ```
+
+   See [Views ▸ Lists & Iteration](views/lists-and-iteration.md#closure-form-foreach) for the full lambda pattern.
 
 ## Shape
 
@@ -121,6 +164,19 @@ new Image("photo").blur(blurAmount)
 | `.searchable(textBinding, prompt)` | `textBinding: String`, `prompt: String` | Adds a search bar |
 | `.badge(value)` | `value: Dynamic` | Badge on tab items or list rows |
 | `.tag(value)` | `value: String` | Tag for Picker selection matching |
+| `.onChange(stateName, action)` | `stateName: String`, `action: StateAction` | Runs a StateAction whenever the named state's value changes. Maps to SwiftUI's `.onChange(of:_:)`. |
+
+The `onChange` modifier is the standard hook to react to a `Picker` selection, a `TextField` edit, or a `Toggle` flip without polling:
+
+```haxe
+new Picker("Mode", "viewMode", [...])
+    .pickerStyle(PickerStyleValue.Segmented)
+    .onChange("viewMode", StateAction.CustomSwift(
+        'Task.detached { _ = HaxeBridgeC.setViewMode(appState.viewMode) }'
+    ))
+```
+
+The generated Swift is `.onChange(of: appState.viewMode) { _, _ in <action> }` — the closure receives both the previous and new values, but the StateAction body can simply read the current `appState.viewMode` since the change has already been applied.
 
 ## Style
 
@@ -128,6 +184,31 @@ new Image("photo").blur(blurAmount)
 |----------|-----------|-------------|
 | `.textFieldStyle(style)` | `style: TextFieldStyleValue` | `.Automatic`, `.RoundedBorder`, `.Plain` |
 | `.listStyle(style)` | `style: String` | `"inset"`, `"grouped"`, `"plain"`, `"sidebar"` |
+| `.buttonStyle(style)` | `style: ButtonStyleValue` | See values below |
+| `.pickerStyle(style)` | `style: PickerStyleValue` | See values below |
+
+**ButtonStyleValue:** `Automatic`, `Plain`, `Borderless`, `Bordered`, `BorderedProminent`, `Link`
+
+```haxe
+new Button("Save", null, saveAction)
+    .buttonStyle(ButtonStyleValue.BorderedProminent)
+```
+
+**PickerStyleValue:** `Automatic`, `Inline`, `Menu`, `Palette`, `Segmented`, `Wheel` (iOS only)
+
+The most useful value on macOS is `Segmented` — the native switcher control with a translucent rounded fill on the selected segment. Standard pattern for view-mode toolbars.
+
+```haxe
+new Picker("View", "viewMode", [
+    new Text("Month").tag("month"),
+    new Text("Week").tag("week"),
+    new Text("Day").tag("day"),
+])
+    .pickerStyle(PickerStyleValue.Segmented)
+    .onChange("viewMode", StateAction.CustomSwift(
+        'Task.detached { _ = HaxeBridgeC.setViewMode(appState.viewMode); await MainActor.run {} }'
+    ))
+```
 
 ## Presentation
 

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -23,6 +23,20 @@ new Button("+", () -> count.value = count.value + 1, count.inc(1))
 | `action` | `() -> Void` | Optional Haxe closure (bridged automatically) |
 | `stateAction` | `StateAction` | Optional declarative state mutation |
 
+**Styling:** chain `.buttonStyle(ButtonStyleValue.…)` to pick a SwiftUI style. Values: `Automatic`, `Plain`, `Borderless`, `Bordered`, `BorderedProminent`, `Link`.
+
+```haxe
+new Button("Save", null, saveAction)
+    .buttonStyle(ButtonStyleValue.BorderedProminent)
+```
+
+**Keyboard shortcut:** chain `.keyboardShortcut(key, modifiers)` to expose the same action as a global ⌘-shortcut. See [Modifiers ▸ Keyboard](../modifiers.md#keyboard).
+
+```haxe
+new Button("New", null, newAction)
+    .keyboardShortcut("n", ["command"])    // ⌘N
+```
+
 ### Button.withView
 
 Use a custom view as the button label:
@@ -128,14 +142,25 @@ new Slider("volume", 0.0, 100.0)
 
 ## Picker
 
-A selection control bound to a `@State` variable.
+A selection control bound to a `@State` variable. Pair with `.pickerStyle(PickerStyleValue.Segmented)` to get the native macOS segmented switcher (translucent rounded fill on the active segment, adapts to dark/light mode automatically); add `.onChange("stateName", action)` to react to selection changes.
 
 ```haxe
 new Picker("Color", "selectedColor", [
-    new Text("Red"),
-    new Text("Green"),
-    new Text("Blue")
+    new Text("Red").tag("red"),
+    new Text("Green").tag("green"),
+    new Text("Blue").tag("blue")
 ])
+
+// Segmented switcher with a reaction:
+new Picker("View", "viewMode", [
+    new Text("Month").tag("month"),
+    new Text("Week").tag("week"),
+    new Text("Day").tag("day"),
+])
+    .pickerStyle(PickerStyleValue.Segmented)
+    .onChange("viewMode", StateAction.CustomSwift(
+        'Task.detached { _ = HaxeBridgeC.setViewMode(appState.viewMode) }'
+    ))
 ```
 
 **Parameters:**
@@ -144,4 +169,8 @@ new Picker("Color", "selectedColor", [
 |-----------|------|-------------|
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
-| `content` | `Array<View>` | Options (typically Text views) |
+| `content` | `Array<View>` | Options (typically Text views with `.tag(value)`) |
+
+The `.tag(value)` modifier on each option binds it to a specific selection value. The Picker writes the tag of the user's pick into the bound state.
+
+**Picker styles** (passed to `.pickerStyle(...)`): `Automatic`, `Inline`, `Menu`, `Palette`, `Segmented`, `Wheel` (iOS only).

--- a/docs/views/lists-and-iteration.md
+++ b/docs/views/lists-and-iteration.md
@@ -22,7 +22,44 @@ Commonly combined with `ForEach` for dynamic content and `Section` for grouping.
 
 ## ForEach
 
-Iterates over a `@State` array to render a view for each element.
+Iterates over a `@State` array to render a view for each element. Two call shapes — the **closure form** is the modern API, the legacy three-arg form is kept for backward compatibility.
+
+### Closure form
+
+```haxe
+new ForEach(colors, color ->
+    new Text(color).tag(color)
+)
+```
+
+Generates:
+
+```swift
+ForEach(colors, id: \.self) { color in
+    Text("\(color)")
+        .tag(color)
+}
+```
+
+The lambda parameter is a typed Haxe value (the array's element type), so references to it inside child views — `Text(color)`, `.tag(color)`, `.foregroundHex(color)`, `.blur(blurAmounts.value[i])` — are checked at compile time and the macro emits the matching Swift expression. **No stringly templates inside modifier args.**
+
+Two AST shapes are recognised inside the lambda:
+
+1. **Bare lambda parameter** — `Text(color)` where `color` is the closure param. Emits the iterated element.
+2. **Indexed parallel-array access** — `Text.withState("{names[i]}").foregroundHex(rowColors.value[i])` where the closure iterates an `Array<Int>` of indices. The macro detects `<State<Array<T>>>.value[<lambdaParam>]` and emits `appState.rowColors[i]`. Useful when multiple parallel state arrays drive one row.
+
+```haxe
+@:state var monthIndices:Array<Int> = [for (i in 0...42) i];
+@:state var monthDayNumbers:Array<String> = [];
+@:state var monthDayColors:Array<String> = [];
+
+new ForEach(monthIndices, i ->
+    Text.withState("{monthDayNumbers[i]}")
+        .foregroundHex(monthDayColors.value[i])
+)
+```
+
+### Legacy 3-arg form
 
 ```haxe
 new ForEach("todos", "i",
@@ -35,7 +72,9 @@ new ForEach("todos", "i",
 )
 ```
 
-**Parameters:**
+The iteration variable name is passed as a String, and modifier args use stringly templates (`"todos[i]"`). Still supported — useful when the body needs raw Swift fragments — but new code should prefer the closure form.
+
+**Parameters (legacy form):**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -43,14 +82,12 @@ new ForEach("todos", "i",
 | `itemName` | `String` | Iteration index variable name in generated Swift |
 | `itemView` | `View` | View rendered for each element |
 
-Access element properties with `Text.withState("{arrayName[itemName].property}")`.
-
 ### List + ForEach Pattern
 
 ```haxe
 new List([
-    new ForEach("items", "i",
-        new Text("Item")  // rendered for each element
+    new ForEach(items, item ->
+        new Text(item)
     )
 ])
 ```


### PR DESCRIPTION
## Summary

A docs-only PR that catches `docs/` up to the features added in the recent batch of feature PRs. None of those PRs touched documentation, so the user-facing manual is currently missing the most useful new primitives.

Once each feature PR lands, the matching doc section here is ready to merge — no extra trip back through the docs to update them per feature.

## What's covered

### docs/modifiers.md

- **Layout** — `.fillWidth` / `.fillHeight` / `.fillBoth` / `.fixedSize(h, v)` table rows plus the rationale (SwiftUI containers collapsing to intrinsic width). Depends on #58.
- **Color & Appearance** — full `.foregroundHex` / `.backgroundHex` section covering all three accepted call shapes: legacy string literal, typed `State<String>` field reference, and closure-form ForEach item ref. Depends on #60 plus the closure-form-modifiers extension currently on a local branch.
- **Style** — new `.buttonStyle(ButtonStyleValue)` (#59) and `.pickerStyle(PickerStyleValue)` (picker-onchange) entries, with the `Segmented` Picker recipe.
- **Interaction** — new `.onChange(stateName, action)` entry, again picker-onchange.

### docs/views/lists-and-iteration.md

- **ForEach** is rewritten to document the closure form as the modern API. Covers bare-lambda-parameter access (`new Text(color)`) and the indexed-parallel-array pattern (`state.value[i]`). The legacy three-arg form is kept under its own subheading for back-compat. Depends on #61 plus the closure-form-modifiers extension.

### docs/views/controls.md

- **Button** gains pointers to `.buttonStyle` and `.keyboardShortcut` with examples — cross-links to the Modifiers ▸ Keyboard section that #66 added.
- **Picker** gains the segmented + `.onChange` recipe and the picker-style table.

### docs/bridge.md

- New **Initial Values Reach Swift** section. Documents that `new State<Bool>(logged, "isLoggedIn")` in the App constructor now reaches AppState on the first render — covers what #65 actually changed, in user terms.
- New **Thread Safety** section. Covers the global `recursive_mutex` + try/catch wrapping every `HaxeBridgeC` entry — `Task.detached` + main-thread shared-memory readers is now a safe combo, and uncaught Haxe `throw`s log to stderr instead of `abort()`-ing. Documents the user-visible contract from #62.

## Why one combined PR?

Each underlying feature PR touched only `.hx` files. The docs sit in shared files (`docs/modifiers.md` is the obvious focal point), so a per-feature doc commit would have conflicted with the next. Keeping the docs as one branch keeps the file order stable; reviewers can also see all the new entries side-by-side.

## Dependencies

- #58 (fill modifiers)
- #59 (buttonStyle)
- #60 (foregroundHex / backgroundHex)
- #61 (ForEach closure form)
- #62 (bridge thread safety)
- #65 (state initial values)
- closure-form-modifiers branch (typed item refs in foregroundHex et al.)
- picker-onchange branch (pickerStyle + onChange)

Some of these are still in review; this PR is safe to merge once they've landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)