### PR TITLE
Add .inspector(binding, content) — macOS trailing inspector pane

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -139,6 +139,19 @@ new Image("photo").blur(blurAmount)
 | `.alert(title, binding, message)` | `title: String`, `binding: State<Bool>`, `message: String` | Alert dialog |
 | `.confirmationDialog(title, binding, content)` | `title: String`, `binding: State<Bool>`, `content: View` | Action sheet |
 | `.contextMenu(content)` | `content: View` | Long-press context menu |
+| `.inspector(binding, content)` | `binding: State<Bool>`, `content: View` | macOS trailing inspector pane — slides out from the right edge when the binding is `true`. Standard pattern for "details about the current selection". |
+
+```haxe
+@:state var showInspector:Bool = false;
+
+new VStack([...])
+    .inspector(showInspector, new VStack([
+        new Text("Details"),
+        Text.withState("Selected: {selectedItem}"),
+    ]))
+```
+
+The Inspector is the macOS-native alternative to a sheet for showing supplementary info — Pages, Numbers, Xcode, Final Cut all use this pattern. On iOS it falls back to a popover.
 
 ```haxe
 new VStack([...])

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -110,6 +110,16 @@ class View {
         return this;
     }
 
+    /** Trailing inspector pane (macOS) — slides out from the right
+        edge when `isPresentedBinding` becomes true. Maps to
+        SwiftUI's `.inspector(isPresented:_:)`. The standard macOS
+        pattern for showing details about the current selection
+        without opening a modal. **/
+    public function inspector(isPresentedBinding:Dynamic, content:View):View {
+        modifierChain.push(ViewModifier.Inspector(isPresentedBinding, content));
+        return this;
+    }
+
     public function alert(title:String, isPresentedBinding:Dynamic, ?message:String):View {
         modifierChain.push(ViewModifier.Alert(title, isPresentedBinding, message));
         return this;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1802,7 +1802,7 @@ class SwiftGenerator {
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
-                 "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
+                 "sheet" | "inspector" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
                  "onAppearAction" | "taskAction" | "toolbarItem" |
@@ -1908,6 +1908,11 @@ class SwiftGenerator {
                 var pad = ind(indent + 1);
                 var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Sheet")\n';
                 'sheet(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
+            case "inspector":
+                var binding = if (args.length > 0) resolveStateName(args[0]) else "isPresented";
+                var pad = ind(indent + 1);
+                var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Inspector")\n';
+                'inspector(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
             case "alert":
                 var title = if (args.length > 0) extractString(args[0]) else "Alert";
                 var binding = if (args.length > 1) resolveStateName(args[1]) else "showAlert";

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -41,6 +41,11 @@ enum ViewModifier {
 
     // Presentation
     Sheet(isPresentedBinding:Dynamic, content:sui.View);
+    /** macOS-style trailing inspector pane — slides out from the
+        right edge of the window when its bound Bool is true.
+        Standard pattern in Mac apps for "details about the current
+        selection" (Pages, Numbers, Xcode). **/
+    Inspector(isPresentedBinding:Dynamic, content:sui.View);
     Alert(title:String, isPresentedBinding:Dynamic, message:Null<String>);
     ConfirmationDialog(title:String, isPresentedBinding:Dynamic, content:sui.View);
 


### PR DESCRIPTION
## Summary

A new `.inspector(binding, content)` modifier mirroring SwiftUI's `.inspector(isPresented:_:)` — the macOS pattern for a right-side pane that shows details about the current selection. Pages, Numbers, Xcode, Final Cut all use it; iOS falls back to a popover.

```haxe
@:state var showInspector:Bool = false;

new VStack([...])
    .inspector(showInspector, new VStack([
        new Text("Details"),
        Text.withState("Selected: {selectedItem}"),
    ]))
```

Emits:

```swift
VStack { … }
    .inspector(isPresented: $showInspector) {
        VStack {
            Text("Details")
            Text("Selected: \(selectedItem)")
        }
    }
```

## Wiring

Mirrors the existing `.sheet` modifier exactly:
- `ViewModifier.Inspector(binding, content)` variant.
- `View.inspector(binding, content)` method.
- `case "inspector"` modifier codegen, resolving the binding through `resolveStateName` so a typed `State<Bool>` field ref works directly.
- `inspector` added to the `isModifier` switch.

## Test plan

- [x] Scratch app with a `@:state var showInspector:Bool` plus a Button toggling it emits the expected `.inspector(isPresented: $showInspector) { … }` block.
- [x] Existing examples unchanged.

## Docs

`docs/modifiers.md` Presentation table gains the `.inspector` row plus a short example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)