### PR TITLE
Add .help(text) modifier — macOS hover tooltip / iOS accessibility hint

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -188,6 +188,7 @@ new VStack([...])
 
 | Modifier | Parameters | Description |
 |----------|-----------|-------------|
+| `.help(text)` | `text: String` | Tooltip shown on hover on macOS, accessibility hint on iOS. |
 | `.accessibilityLabel(label)` | `label: String` | Screen reader label |
 
 ## Animation

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -246,6 +246,13 @@ class View {
         return this;
     }
 
+    /** Tooltip text shown on hover on macOS (and used as an
+        accessibility hint on iOS). Maps to SwiftUI's `.help(_:)`. **/
+    public function help(text:String):View {
+        modifierChain.push(ViewModifier.Help(text));
+        return this;
+    }
+
     /** Adjust brightness. Pass a Float or a State<Float>. **/
     public function brightness(amount:sui.state.StateOr<Float>):View {
         modifierChain.push(ViewModifier.Brightness(amount));

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1809,7 +1809,7 @@ class SwiftGenerator {
                  "blur" | "scaleEffect" | "rotationEffect" | "offset" |
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
-                 "listStyle" | "aspectRatio" | "accessibilityLabel" |
+                 "listStyle" | "aspectRatio" | "accessibilityLabel" | "help" |
                  "onSubmit" | "onLongPressGesture" | "transition":
                 true;
             default: false;
@@ -2038,6 +2038,9 @@ class SwiftGenerator {
             case "accessibilityLabel":
                 var s = if (args.length > 0) extractString(args[0]) else "";
                 'accessibilityLabel("${esc(s != null ? s : "")}")';
+            case "help":
+                var s = if (args.length > 0) extractString(args[0]) else "";
+                'help("${esc(s != null ? s : "")}")';
 
             // --- Interaction ---
             case "onSubmit":

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -96,6 +96,9 @@ enum ViewModifier {
 
     // Accessibility
     AccessibilityLabel(label:String);
+    /** SwiftUI `.help("…")` — tooltip text shown on hover on macOS,
+        accessibility hint on iOS. **/
+    Help(text:String);
 
     // Interaction
     OnSubmit(actionId:Int);


### PR DESCRIPTION
## Summary

`new Button("", null, action).help("Refresh the list (⌘R)")` — standard macOS chrome for icon-only buttons. Maps to SwiftUI's `.help(_:)`.

Wiring mirrors `.accessibilityLabel` exactly: `ViewModifier.Help(text)` variant, `View.help(text)` method, one-line codegen branch (`'help("…")'`), `help` added to the `isModifier` switch. `docs/modifiers.md` Accessibility table gains the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)