### PR TITLE
Add ShareLink view — system share sheet trigger

### DIFF
--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -126,6 +126,25 @@ new Slider("volume", 0.0, 100.0)
 | `rangeMin` | `Float` | Minimum value |
 | `rangeMax` | `Float` | Maximum value |
 
+## ShareLink
+
+A button that triggers the system share sheet — macOS Share menu on Mac, `UIActivityViewController` on iOS / iPadOS / visionOS. Maps to SwiftUI's `ShareLink(item:)`.
+
+```haxe
+// Default UI — system share-arrow icon
+new ShareLink("https://example.com")
+
+// Custom label
+new ShareLink("https://example.com", "Share this link")
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `item` | `String` | The thing being shared. SwiftUI auto-detects URLs vs plain text from the string. |
+| `label` | `String` (optional) | Custom label text. Without it, the default share-arrow icon is shown. |
+
 ## Picker
 
 A selection control bound to a `@State` variable.

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1203,6 +1203,17 @@ class SwiftGenerator {
                 var url = if (args.length > 1) extractString(args[1]) else "";
                 return '${pad}Link("${esc(label != null ? label : "")}", destination: URL(string: "${esc(url != null ? url : "")}")!)\n';
 
+            case "ShareLink":
+                // args[0]: item (String). args[1]: optional label
+                // String — without it, SwiftUI shows the default
+                // share-arrow icon.
+                var item = if (args.length > 0) extractString(args[0]) else "";
+                var label = if (args.length > 1) extractString(args[1]) else null;
+                if (label != null && label != "")
+                    return '${pad}ShareLink(item: "${esc(item != null ? item : "")}") {\n${pad}    Text("${esc(label)}")\n${pad}}\n';
+                else
+                    return '${pad}ShareLink(item: "${esc(item != null ? item : "")}")\n';
+
             case "Image":
                 if (args.length > 0) {
                     var n = extractString(args[0]);

--- a/src/sui/ui/ShareLink.hx
+++ b/src/sui/ui/ShareLink.hx
@@ -1,0 +1,36 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A button that triggers the system share sheet. Maps to SwiftUI's
+    `ShareLink(item:)`.
+
+    The `item` is what gets shared — for v1 this is always a `String`,
+    which SwiftUI auto-detects as a URL when it parses as one, or as
+    plain text otherwise. Passing an optional `label` lets you
+    override the default share-arrow icon.
+
+    ```haxe
+    // Default UI (system share-arrow icon)
+    new ShareLink("https://example.com")
+
+    // Custom label
+    new ShareLink("https://example.com", "Share this link")
+    ```
+
+    On macOS opens the system Share menu; on iOS / iPadOS / visionOS
+    opens the activity controller (UIActivityViewController).
+**/
+@:swiftView("ShareLink")
+class ShareLink extends View {
+    public var item:String;
+    public var label:Null<String>;
+
+    public function new(@:swiftLabel("item") item:String, ?label:String) {
+        super();
+        this.viewType = "ShareLink";
+        this.item = item;
+        this.label = label;
+    }
+}


### PR DESCRIPTION
## Summary

`new ShareLink(item, ?label)` — the system share sheet trigger, mapping to SwiftUI's `ShareLink(item:)`. Opens the macOS Share menu on Mac and `UIActivityViewController` on iOS / iPadOS / visionOS.

```haxe
new ShareLink("https://example.com")
new ShareLink("https://example.com", "Share this link")
```

Emits:

```swift
ShareLink(item: "https://example.com")
ShareLink(item: "https://example.com") { Text("Share this link") }
```

## Wiring

- `sui/ui/ShareLink.hx` — `@:swiftView("ShareLink")` View subclass.
- `case "ShareLink"` in the macro: extract the item String, optionally the label String, emit either the short form or a labelled form.

`item` is a `String` for v1 — SwiftUI auto-detects URLs vs plain text from the string. Supporting `URL`, `Image`, custom `Codable` items, etc. can come in follow-ups.

## Docs

`docs/views/controls.md` gains a ShareLink section right before Picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)