### PR TITLE
Add .onKeyPress(key, action) modifier

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -153,6 +153,7 @@ new VStack([...])
 |----------|-----------|-------------|
 | `.onTapGesture(action)` | `action: StateAction` | Runs a StateAction when tapped |
 | `.onLongPressGesture(action)` | `action: StateAction` | Runs a StateAction on long press |
+| `.onKeyPress(key, action)` | `key: String`, `action: StateAction` | Runs a StateAction when the named key is pressed while the view (or a descendant) has focus. |
 
 ```haxe
 new Text("Tap me")
@@ -160,7 +161,14 @@ new Text("Tap me")
 
 new Text("Hold me")
     .onLongPressGesture(showMenu.tog())
+
+// Key press handlers — same key-naming as keyboardShortcut
+new VStack([...])
+    .onKeyPress("escape", dismissAction)
+    .onKeyPress("right", nextAction)
 ```
+
+`onKeyPress` uses the same `key` strings as `.keyboardShortcut` — single chars or named special keys: `"return"`, `"escape"`, `"delete"`, `"tab"`, `"space"`, `"left"` / `"right"` / `"up"` / `"down"`, `"home"`, `"end"`, `"pageup"` / `"pagedown"`. The action runs only when the view (or a descendant) has keyboard focus; the handler returns `.handled` so SwiftUI stops bubbling the event up the focus chain.
 
 ## Lifecycle
 

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -290,6 +290,16 @@ class View {
         return this;
     }
 
+    /** Run a `StateAction` when the given key is pressed while
+        this view (or a descendant) has focus. Maps to SwiftUI's
+        `.onKeyPress(_:action:)`. Use the same key-naming scheme
+        as `.keyboardShortcut` — single chars or named special
+        keys (`"return"`, `"escape"`, `"left"`, …). **/
+    public function onKeyPress(key:String, action:sui.state.StateAction):View {
+        modifierChain.push(ViewModifier.OnKeyPress(key, action));
+        return this;
+    }
+
     /** Run a StateAction when the view appears. **/
     public function onAppearAction(action:sui.state.StateAction):View {
         modifierChain.push(ViewModifier.OnAppearAction(action));

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1810,7 +1810,7 @@ class SwiftGenerator {
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" |
-                 "onSubmit" | "onLongPressGesture" | "transition":
+                 "onSubmit" | "onLongPressGesture" | "transition" | "onKeyPress":
                 true;
             default: false;
         }
@@ -2049,6 +2049,16 @@ class SwiftGenerator {
                     'onLongPressGesture { ${actionCode} }';
                 else
                     'onLongPressGesture { }';
+            case "onKeyPress":
+                // args[0]: key name (String). args[1]: StateAction.
+                // Emits `.onKeyPress(<keyEquivalent>) { <action>; return .handled }`
+                // — `.handled` stops SwiftUI bubbling the event up the
+                // focus chain, the right default for an explicit handler.
+                var key = if (args.length > 0) extractString(args[0]) else "";
+                if (key == null) key = "";
+                var keyExpr = keyPressEquivalentToSwift(key);
+                var actionCode = if (args.length > 1) stateActionToSwift(args[1]) else "";
+                'onKeyPress(${keyExpr}) { ${actionCode}; return .handled }';
 
             default:
                 // Generic: try to pass through args
@@ -2235,6 +2245,31 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Map a sui key-name string to the matching SwiftUI
+        `KeyEquivalent` for `.onKeyPress`. Named keys resolve to
+        their static properties; anything else is wrapped in
+        `KeyEquivalent("<char>")`. Duplicates the logic
+        `feat/keyboard-shortcut` adds for `.keyboardShortcut`'s
+        `keyEquivalentToSwift` — to be deduped when both land. **/
+    static function keyPressEquivalentToSwift(key:String):String {
+        return switch (key.toLowerCase()) {
+            case "return": ".return";
+            case "escape": ".escape";
+            case "delete" | "backspace": ".delete";
+            case "tab": ".tab";
+            case "space": ".space";
+            case "left": ".leftArrow";
+            case "right": ".rightArrow";
+            case "up": ".upArrow";
+            case "down": ".downArrow";
+            case "home": ".home";
+            case "end": ".end";
+            case "pageup": ".pageUp";
+            case "pagedown": ".pageDown";
+            default: 'KeyEquivalent("${esc(key)}")';
+        };
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -100,6 +100,14 @@ enum ViewModifier {
     // Interaction
     OnSubmit(actionId:Int);
     OnLongPressGesture(action:sui.state.StateAction);
+    /** SwiftUI `.onKeyPress(_:action:)` — runs a `StateAction` when
+        a key is pressed while this view (or a descendant) has
+        focus. The `key` follows the same naming convention as
+        `.keyboardShortcut` (single char or named special key:
+        `return`, `escape`, `delete`, `tab`, `space`,
+        `left` / `right` / `up` / `down`, `home`, `end`,
+        `pageup` / `pagedown`). **/
+    OnKeyPress(key:String, action:sui.state.StateAction);
 
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);


### PR DESCRIPTION
## Summary

Adds a `.onKeyPress(key, action)` modifier mapping to SwiftUI's `.onKeyPress(_:action:)`. The action runs when the named key is pressed while the receiving view (or a descendant) has keyboard focus.

```haxe
new VStack([...])
    .onKeyPress("escape", dismissAction)
    .onKeyPress("right", nextAction)
    .onKeyPress("a", focusFirstAction)
```

Emits:

```swift
VStack { … }
    .onKeyPress(.escape) { dismissAction; return .handled }
    .onKeyPress(.rightArrow) { nextAction; return .handled }
    .onKeyPress(KeyEquivalent("a")) { focusFirstAction; return .handled }
```

The handler always returns `.handled` so SwiftUI stops bubbling the event up the focus chain — the right default for an explicit, opinionated handler.

## Wiring

- `ViewModifier.OnKeyPress(key, action)` variant.
- `View.onKeyPress(key, action)` method.
- New `keyPressEquivalentToSwift` helper maps key names to SwiftUI `KeyEquivalent` (same list as keyboardShortcut: `return`, `escape`, `delete`, `tab`, `space`, `left`/`right`/`up`/`down`, `home`, `end`, `pageup`/`pagedown`).
- `case "onKeyPress"` modifier codegen.
- `onKeyPress` added to the `isModifier` switch.

## Overlap with #66

[#66 (`feat/keyboard-shortcut`)](https://github.com/Pign/sui/pull/66) introduces a near-identical `keyEquivalentToSwift` helper for the `.keyboardShortcut` modifier. Both PRs are off main, so they're independent — they should be deduped (one helper, shared) once both land. Comment in the new helper flags this explicitly.

## Test plan

- [x] A scratch app with `.onKeyPress("escape", …)`, `.onKeyPress("right", …)`, `.onKeyPress("a", …)` emits the expected `.onKeyPress(.escape)`, `.onKeyPress(.rightArrow)`, `.onKeyPress(KeyEquivalent("a"))` Swift.
- [x] Existing examples build unchanged.

## Docs

`docs/modifiers.md` Gestures section gains the `.onKeyPress` row plus an example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)