### PR TITLE
Add .backgroundMaterial(style) — translucent SwiftUI Material backgrounds

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -56,8 +56,21 @@ new Text("Styled")
 |----------|-----------|-------------|
 | `.foregroundColor(color)` | `color: ColorValue` | Text/icon color |
 | `.background(color)` | `color: ColorValue` | Background color |
+| `.backgroundMaterial(style)` | `style: MaterialStyle` | Translucent frosted-glass background (`.regularMaterial`, etc.) — adapts to dark/light, picks up content behind. |
 | `.opacity(value)` | `value: Float` | Opacity (0.0 to 1.0) |
 | `.tint(color)` | `color: ColorValue` | Accent/tint color |
+
+**MaterialStyle values:** `Regular`, `Thin`, `UltraThin`, `Thick`, `UltraThick`, `Bar`
+
+The `.backgroundMaterial` modifier gives you the translucent frosted-glass treatment that macOS uses on sidebars, popovers and toolbars. Each style is a different thickness — `Thin` lets more of the underlying content through, `Thick` is more opaque. `Bar` is the toolbar-specific variant.
+
+```haxe
+new VStack([...])
+    .backgroundMaterial(MaterialStyle.Regular)
+
+new VStack([...])
+    .backgroundMaterial(MaterialStyle.Bar)
+```
 
 **ColorValue values:** `Primary`, `Secondary`, `Accent`, `Red`, `Orange`, `Yellow`, `Green`, `Blue`, `Purple`, `Pink`, `White`, `Black`, `Gray`, `Clear`, `Custom(hex)`
 

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -55,6 +55,14 @@ class View {
         return this;
     }
 
+    /** Translucent SwiftUI `Material` as a background fill — picks
+        up content behind, adapts to dark/light mode automatically.
+        Standard in macOS sidebars, popovers, toolbars. **/
+    public function backgroundMaterial(style:MaterialStyle):View {
+        modifierChain.push(ViewModifier.BackgroundMaterial(style));
+        return this;
+    }
+
     public function cornerRadius(radius:Float):View {
         modifierChain.push(ViewModifier.CornerRadius(radius));
         return this;
@@ -382,4 +390,15 @@ enum TextFieldStyleValue {
     Automatic;
     RoundedBorder;
     Plain;
+}
+
+enum MaterialStyle {
+    /** The system default — `.regularMaterial`. Mid-thickness frosted glass. **/
+    Regular;
+    Thin;
+    UltraThin;
+    Thick;
+    UltraThick;
+    /** Bar-style material — used by `.bar`. Slightly tinted for toolbars. **/
+    Bar;
 }

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1798,7 +1798,7 @@ class SwiftGenerator {
 
     static function isModifier(name:String):Bool {
         return switch (name) {
-            case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
+            case "padding" | "font" | "foregroundColor" | "background" | "backgroundMaterial" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1830,6 +1830,14 @@ class SwiftGenerator {
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'background(.${e != null ? camel(e) : "clear"})';
+            case "backgroundMaterial":
+                // MaterialStyle enum → SwiftUI Material constant.
+                // Regular → .regularMaterial, Bar → .bar, etc.
+                var e = if (args.length > 0) extractEnumName(args[0]) else null;
+                var swift = if (e == "Bar") ".bar"
+                    else if (e == null) ".regularMaterial"
+                    else '.${camel(e)}Material';
+                'background(${swift})';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -22,6 +22,10 @@ enum ViewModifier {
     // Colors & Appearance
     ForegroundColor(color:ColorValue);
     Background(color:ColorValue);
+    /** Translucent SwiftUI Material as a background fill — picks up
+        content behind it. Standard in macOS sidebars, popovers, and
+        toolbars. **/
+    BackgroundMaterial(style:sui.View.MaterialStyle);
     Opacity(value:Float);
 
     // Shape


### PR DESCRIPTION
## Summary

`new VStack([...]).backgroundMaterial(MaterialStyle.Regular)` — translucent frosted-glass background that picks up content behind and adapts to dark/light mode. Maps to SwiftUI's `.background(.<material>)`. Standard macOS treatment for sidebars, popovers, and toolbar backgrounds.

```haxe
new VStack([...])
    .backgroundMaterial(MaterialStyle.Regular)

new VStack([...])
    .backgroundMaterial(MaterialStyle.Bar)   // toolbar-specific
```

Emits:

```swift
VStack { … }
    .background(.regularMaterial)
VStack { … }
    .background(.bar)
```

## Wiring

- `MaterialStyle` enum on `sui.View`: `Regular`, `Thin`, `UltraThin`, `Thick`, `UltraThick`, `Bar`.
- `ViewModifier.BackgroundMaterial(style)` variant.
- `View.backgroundMaterial(style)` method.
- `case "backgroundMaterial"` codegen: maps `Bar` → `.bar`, anything else → `.<camelCase>Material`.
- `backgroundMaterial` added to the `isModifier` switch.

## Docs

`docs/modifiers.md` Color & Appearance section gains the entry + the `MaterialStyle` values table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)