### PR TITLE
Add Rectangle / Circle / Capsule / Ellipse shape primitives

### DIFF
--- a/docs/views/layout.md
+++ b/docs/views/layout.md
@@ -92,6 +92,30 @@ new VStack([
 |-----------|------|---------|-------------|
 | `minLength` | `Float` | `null` | Minimum size |
 
+## Shape primitives
+
+`Rectangle`, `Circle`, `Capsule`, `Ellipse` are zero-arg shape views that map to their SwiftUI equivalents. Like all SwiftUI shapes, they have no intrinsic size — give them one via `.frame(...)` (or rely on the parent layout to size them). Fill with `.foregroundColor(...)` / `.foregroundHex(...)`.
+
+```haxe
+new Rectangle()
+    .frame(100, 50)
+    .foregroundColor(ColorValue.Blue)
+
+new Circle()
+    .frame(20, 20)
+    .foregroundColor(ColorValue.Red)
+
+new Capsule()
+    .frame(100, 24)
+    .foregroundColor(ColorValue.Accent)
+
+new Ellipse()
+    .frame(100, 50)
+    .foregroundColor(ColorValue.Purple)
+```
+
+Useful as drawing primitives, decoration, overlays, and for chip-style backgrounds where a plain `cornerRadius` isn't enough. For more complex curves use `Path` (not yet wrapped) via `CustomSwift`.
+
 ## ScrollView
 
 Wraps content in a scrollable container.

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1037,6 +1037,11 @@ class SwiftGenerator {
                 }
                 return buf.toString();
 
+            case "Rectangle": return '${pad}Rectangle()\n';
+            case "Circle": return '${pad}Circle()\n';
+            case "Capsule": return '${pad}Capsule()\n';
+            case "Ellipse": return '${pad}Ellipse()\n';
+
             case "Spacer":
                 if (args.length > 0) {
                     var v = extractConstant(args[0]);

--- a/src/sui/ui/Capsule.hx
+++ b/src/sui/ui/Capsule.hx
@@ -1,0 +1,21 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A capsule (stadium / pill) shape primitive — like a rectangle
+    with fully rounded short edges. Maps to SwiftUI's `Capsule`.
+
+    ```haxe
+    new Capsule()
+        .frame(100, 24)
+        .foregroundColor(ColorValue.Accent)
+    ```
+**/
+@:swiftView("Capsule")
+class Capsule extends View {
+    public function new() {
+        super();
+        this.viewType = "Capsule";
+    }
+}

--- a/src/sui/ui/Circle.hx
+++ b/src/sui/ui/Circle.hx
@@ -1,0 +1,23 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A circular shape primitive. Maps to SwiftUI's `Circle`.
+
+    Fits inside the bounds of its container — give it a square
+    `.frame(...)` for a true circle.
+
+    ```haxe
+    new Circle()
+        .frame(20, 20)
+        .foregroundColor(ColorValue.Red)
+    ```
+**/
+@:swiftView("Circle")
+class Circle extends View {
+    public function new() {
+        super();
+        this.viewType = "Circle";
+    }
+}

--- a/src/sui/ui/Ellipse.hx
+++ b/src/sui/ui/Ellipse.hx
@@ -1,0 +1,22 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    An ellipse shape primitive — fills the bounds of its container,
+    so the aspect ratio is determined by `.frame(width, height)`.
+    Maps to SwiftUI's `Ellipse`.
+
+    ```haxe
+    new Ellipse()
+        .frame(100, 50)
+        .foregroundColor(ColorValue.Purple)
+    ```
+**/
+@:swiftView("Ellipse")
+class Ellipse extends View {
+    public function new() {
+        super();
+        this.viewType = "Ellipse";
+    }
+}

--- a/src/sui/ui/Rectangle.hx
+++ b/src/sui/ui/Rectangle.hx
@@ -1,0 +1,24 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A rectangular shape primitive. Maps to SwiftUI's `Rectangle`.
+
+    Like all SwiftUI shapes, it has no intrinsic size — give it one
+    via `.frame(...)` or rely on the parent layout to size it.
+    Fill with `.foregroundColor(...)` or `.foregroundHex(...)`.
+
+    ```haxe
+    new Rectangle()
+        .frame(100, 50)
+        .foregroundColor(ColorValue.Blue)
+    ```
+**/
+@:swiftView("Rectangle")
+class Rectangle extends View {
+    public function new() {
+        super();
+        this.viewType = "Rectangle";
+    }
+}


### PR DESCRIPTION
## Summary

Adds the four basic SwiftUI shape primitives. Zero-arg views that map 1:1 to their SwiftUI equivalents — size them with `.frame(...)`, fill them with `.foregroundColor(...)` or `.foregroundHex(...)`.

```haxe
new Rectangle().frame(100, 50).foregroundColor(ColorValue.Blue)
new Circle().frame(20, 20).foregroundColor(ColorValue.Red)
new Capsule().frame(100, 24)
new Ellipse().frame(100, 50)
```

Generates:

```swift
Rectangle().frame(width: 100, height: 50).foregroundStyle(.blue)
Circle().frame(width: 20, height: 20).foregroundStyle(.red)
Capsule().frame(width: 100, height: 24)
Ellipse().frame(width: 100, height: 50)
```

## Wiring

- Four new `@:swiftView`-tagged classes in `sui/ui/`: `Rectangle.hx`, `Circle.hx`, `Capsule.hx`, `Ellipse.hx`.
- Four single-line `case "<Shape>"` codegen branches in `SwiftGenerator.newToSwift`.

## Test plan

- [x] A scratch app with each of the four shapes (sized + colour-filled) emits the expected Swift.
- [x] Existing examples build unchanged.

## Docs

`docs/views/layout.md` gains a "Shape primitives" section right before ScrollView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)