### PR TITLE
Add LinearGradient / RadialGradient / AngularGradient views

### DIFF
--- a/docs/views/layout.md
+++ b/docs/views/layout.md
@@ -92,6 +92,38 @@ new VStack([
 |-----------|------|---------|-------------|
 | `minLength` | `Float` | `null` | Minimum size |
 
+## Gradients
+
+Three gradient views — `LinearGradient`, `RadialGradient`, `AngularGradient` — map to their SwiftUI equivalents. Like shapes, they have no intrinsic size; use `.frame(...)` or place them as a `.background(...)` overlay.
+
+```haxe
+new LinearGradient(
+    [ColorValue.Blue, ColorValue.Purple],
+    "top", "bottom"
+)
+
+new RadialGradient(
+    [ColorValue.Yellow, ColorValue.Red],
+    "center", 0, 100
+)
+
+new AngularGradient(
+    [ColorValue.Red, ColorValue.Orange, ColorValue.Yellow,
+     ColorValue.Green, ColorValue.Blue, ColorValue.Purple],
+    "center"
+)
+```
+
+Generates:
+
+```swift
+LinearGradient(colors: [.blue, .purple], startPoint: .top, endPoint: .bottom)
+RadialGradient(colors: [.yellow, .red], center: .center, startRadius: 0, endRadius: 100)
+AngularGradient(colors: [.red, .orange, .yellow, .green, .blue, .purple], center: .center)
+```
+
+**Unit-point strings** (start/end/center): `"top"`, `"bottom"`, `"leading"`, `"trailing"`, `"topLeading"`, `"topTrailing"`, `"bottomLeading"`, `"bottomTrailing"`, `"center"`.
+
 ## ScrollView
 
 Wraps content in a scrollable container.

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1037,6 +1037,32 @@ class SwiftGenerator {
                 }
                 return buf.toString();
 
+            case "LinearGradient":
+                // args[0] = TArrayDecl<ColorValue>, args[1] = startPoint String,
+                // args[2] = endPoint String.
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var start = args.length > 1 ? extractString(args[1]) : "top";
+                var end = args.length > 2 ? extractString(args[2]) : "bottom";
+                if (start == null) start = "top";
+                if (end == null) end = "bottom";
+                return '${pad}LinearGradient(colors: ${swiftColors}, startPoint: .${esc(start)}, endPoint: .${esc(end)})\n';
+
+            case "RadialGradient":
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var center = args.length > 1 ? extractString(args[1]) : "center";
+                var startR = args.length > 2 ? extractConstant(args[2]) : "0";
+                var endR = args.length > 3 ? extractConstant(args[3]) : "100";
+                if (center == null) center = "center";
+                if (startR == null) startR = "0";
+                if (endR == null) endR = "100";
+                return '${pad}RadialGradient(colors: ${swiftColors}, center: .${esc(center)}, startRadius: ${startR}, endRadius: ${endR})\n';
+
+            case "AngularGradient":
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var center = args.length > 1 ? extractString(args[1]) : "center";
+                if (center == null) center = "center";
+                return '${pad}AngularGradient(colors: ${swiftColors}, center: .${esc(center)})\n';
+
             case "Spacer":
                 if (args.length > 0) {
                     var v = extractConstant(args[0]);
@@ -2235,6 +2261,26 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Translate a TArrayDecl of `ColorValue` enum constants into a
+        Swift literal `[.red, .blue, …]`. Used by the gradient
+        views. Unknown / non-enum entries fall through to
+        `.primary` to keep the array length matched. **/
+    static function extractColorArrayToSwift(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "[]";
+        var e = unwrap(expr);
+        switch (e.expr) {
+            case TArrayDecl(elems):
+                var parts:Array<String> = [];
+                for (el in elems) {
+                    var name = extractEnumName(el);
+                    parts.push(name != null ? '.${camel(name)}' : ".primary");
+                }
+                return '[${parts.join(", ")}]';
+            default:
+        }
+        return "[]";
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/ui/AngularGradient.hx
+++ b/src/sui/ui/AngularGradient.hx
@@ -1,0 +1,31 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    An angular (conic) gradient — colours laid out around a centre
+    point, sweeping a full circle. Maps to SwiftUI's
+    `AngularGradient`.
+
+    ```haxe
+    new AngularGradient(
+        [ColorValue.Red, ColorValue.Orange, ColorValue.Yellow, ColorValue.Green, ColorValue.Blue, ColorValue.Purple, ColorValue.Red],
+        "center"
+    )
+    ```
+
+    `center` is one of the unit-point strings (`"center"`,
+    `"top"`, `"topLeading"`, …).
+**/
+@:swiftView("AngularGradient")
+class AngularGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var center:String;
+
+    public function new(colors:Array<ColorValue>, center:String) {
+        super();
+        this.viewType = "AngularGradient";
+        this.colors = colors;
+        this.center = center;
+    }
+}

--- a/src/sui/ui/LinearGradient.hx
+++ b/src/sui/ui/LinearGradient.hx
@@ -1,0 +1,38 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A linear gradient — colours laid out along a straight line
+    between two unit points. Maps to SwiftUI's `LinearGradient`.
+
+    ```haxe
+    new LinearGradient(
+        [ColorValue.Blue, ColorValue.Purple],
+        "top",
+        "bottom"
+    )
+    ```
+
+    Common unit-point strings: `"top"`, `"bottom"`, `"leading"`,
+    `"trailing"`, `"topLeading"`, `"topTrailing"`,
+    `"bottomLeading"`, `"bottomTrailing"`, `"center"`.
+
+    Like all gradients, has no intrinsic size — use `.frame(...)`
+    or rely on the parent to size it. Often used as a `.background`
+    or inside a `.foregroundColor` style.
+**/
+@:swiftView("LinearGradient")
+class LinearGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var startPoint:String;
+    public var endPoint:String;
+
+    public function new(colors:Array<ColorValue>, startPoint:String, endPoint:String) {
+        super();
+        this.viewType = "LinearGradient";
+        this.colors = colors;
+        this.startPoint = startPoint;
+        this.endPoint = endPoint;
+    }
+}

--- a/src/sui/ui/RadialGradient.hx
+++ b/src/sui/ui/RadialGradient.hx
@@ -1,0 +1,37 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A radial gradient — colours laid out in concentric rings from a
+    centre point. Maps to SwiftUI's `RadialGradient`.
+
+    ```haxe
+    new RadialGradient(
+        [ColorValue.Yellow, ColorValue.Red],
+        "center",
+        0,
+        100
+    )
+    ```
+
+    `center` is one of the unit-point strings (`"center"`,
+    `"top"`, `"topLeading"`, …). `startRadius` / `endRadius` are
+    in points.
+**/
+@:swiftView("RadialGradient")
+class RadialGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var center:String;
+    public var startRadius:Float;
+    public var endRadius:Float;
+
+    public function new(colors:Array<ColorValue>, center:String, startRadius:Float, endRadius:Float) {
+        super();
+        this.viewType = "RadialGradient";
+        this.colors = colors;
+        this.center = center;
+        this.startRadius = startRadius;
+        this.endRadius = endRadius;
+    }
+}


### PR DESCRIPTION
## Summary

Three gradient views mapping to their SwiftUI equivalents:

```haxe
new LinearGradient([ColorValue.Blue, ColorValue.Purple], "top", "bottom")

new RadialGradient([ColorValue.Yellow, ColorValue.Red], "center", 0, 100)

new AngularGradient(
    [ColorValue.Red, ColorValue.Orange, ColorValue.Yellow,
     ColorValue.Green, ColorValue.Blue, ColorValue.Purple],
    "center"
)
```

Emits:

```swift
LinearGradient(colors: [.blue, .purple], startPoint: .top, endPoint: .bottom)
RadialGradient(colors: [.yellow, .red], center: .center, startRadius: 0, endRadius: 100)
AngularGradient(colors: [.red, .orange, …], center: .center)
```

## Wiring

- Three new `@:swiftView`-tagged classes in `sui/ui/`.
- Three explicit `case` branches in `newToSwift`.
- New `extractColorArrayToSwift(expr)` helper for the `[ColorValue.*, …]` → `[.red, .blue, …]` translation. Unknown entries fall through to `.primary`.

## Docs

`docs/views/layout.md` gets a Gradients section right before ScrollView, with the three usage examples and the unit-point reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)