### PR TITLE
Add .inspectorColumnWidth(min, ideal, max)

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -140,6 +140,7 @@ new Image("photo").blur(blurAmount)
 | `.confirmationDialog(title, binding, content)` | `title: String`, `binding: State<Bool>`, `content: View` | Action sheet |
 | `.contextMenu(content)` | `content: View` | Long-press context menu |
 | `.inspector(binding, content)` | `binding: State<Bool>`, `content: View` | macOS trailing inspector pane — slides out from the right edge when the binding is `true`. Standard pattern for "details about the current selection". |
+| `.inspectorColumnWidth(min, ideal, max)` | `min: Float`, `ideal: Float`, `max: Float` | Width hint for the Inspector column. SwiftUI defaults to a narrow track that can shrink further on window resize — set explicit bounds here whenever the inspector content has its own intrinsic width (forms, multi-column lists, etc.). Apply on the same view that owns `.inspector(...)`. |
 
 ```haxe
 @:state var showInspector:Bool = false;
@@ -149,9 +150,12 @@ new VStack([...])
         new Text("Details"),
         Text.withState("Selected: {selectedItem}"),
     ]))
+    .inspectorColumnWidth(360, 480, 720)
 ```
 
 The Inspector is the macOS-native alternative to a sheet for showing supplementary info — Pages, Numbers, Xcode, Final Cut all use this pattern. On iOS it falls back to a popover.
+
+`.inspectorColumnWidth(min, ideal, max)` is almost always wanted alongside `.inspector(...)` — without it the column lands at SwiftUI's default (~250pt) and can shrink further when the user resizes the window, which is too tight for anything other than a key/value detail list.
 
 ```haxe
 new VStack([...])

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -120,6 +120,22 @@ class View {
         return this;
     }
 
+    /** Set the Inspector column's `min` / `ideal` / `max` widths.
+        SwiftUI defaults the Inspector column to a narrow ~250pt
+        track that can shrink further when the window resizes —
+        too tight for anything beyond simple key/value detail
+        lists. Apply this directly after `.inspector(...)`:
+        ```haxe
+        myView
+            .inspector("editorOpen", buildEditor())
+            .inspectorColumnWidth(360, 480, 720);
+        ```
+        Maps to `.inspectorColumnWidth(min:ideal:max:)`. **/
+    public function inspectorColumnWidth(min:Float, ideal:Float, max:Float):View {
+        modifierChain.push(ViewModifier.InspectorColumnWidth(min, ideal, max));
+        return this;
+    }
+
     public function alert(title:String, isPresentedBinding:Dynamic, ?message:String):View {
         modifierChain.push(ViewModifier.Alert(title, isPresentedBinding, message));
         return this;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1802,7 +1802,7 @@ class SwiftGenerator {
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
-                 "sheet" | "inspector" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
+                 "sheet" | "inspector" | "inspectorColumnWidth" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
                  "onAppearAction" | "taskAction" | "toolbarItem" |
@@ -1913,6 +1913,14 @@ class SwiftGenerator {
                 var pad = ind(indent + 1);
                 var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Inspector")\n';
                 'inspector(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
+            case "inspectorColumnWidth":
+                var mn = if (args.length > 0) extractConstant(args[0]) else null;
+                var id = if (args.length > 1) extractConstant(args[1]) else null;
+                var mx = if (args.length > 2) extractConstant(args[2]) else null;
+                if (mn == null) mn = "200";
+                if (id == null) id = "300";
+                if (mx == null) mx = "600";
+                'inspectorColumnWidth(min: ${mn}, ideal: ${id}, max: ${mx})';
             case "alert":
                 var title = if (args.length > 0) extractString(args[0]) else "Alert";
                 var binding = if (args.length > 1) resolveStateName(args[1]) else "showAlert";

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -46,6 +46,9 @@ enum ViewModifier {
         Standard pattern in Mac apps for "details about the current
         selection" (Pages, Numbers, Xcode). **/
     Inspector(isPresentedBinding:Dynamic, content:sui.View);
+    /** Width hint for the Inspector column: `min` / `ideal` / `max`.
+        Apply on the same view that owns the `.inspector(...)` call. **/
+    InspectorColumnWidth(min:Float, ideal:Float, max:Float);
     Alert(title:String, isPresentedBinding:Dynamic, message:Null<String>);
     ConfirmationDialog(title:String, isPresentedBinding:Dynamic, content:sui.View);
 


### PR DESCRIPTION
SwiftUI's `.inspector(...)` defaults the trailing column to a narrow ~250pt track that shrinks further on window resize. Fine for simple key/value detail panes, but collapses to an unusable strip the moment the content is a form or multi-column layout — the exact case inspectors are most often used for in real apps.

This PR adds a thin wrapper around SwiftUI's `.inspectorColumnWidth(min:ideal:max:)` so the caller can express the column's natural width alongside the inspector declaration:

```haxe
myView
    .inspector("editorOpen", buildEditor())

// inside the inspector closure, on the content view:
buildEditor()
    .inspectorColumnWidth(360, 480, 720)
```

The modifier emits a plain SwiftUI call — no special handling needed in the bridged / state-rewrite paths since it carries no references to user state.

## Stack

Stacks on #feat/inspector-modifier. Targeting that branch; rebase onto `main` once `feat/inspector-modifier` is merged.