### PR TITLE
Rewrite state refs to appState.X in scene-level commands block

### DIFF
--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,51 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## CommandMenu (macOS menu bar)
+
+A top-level menu in the macOS menu bar — appears next to **File / Edit / View / Help**. Maps to SwiftUI's `CommandMenu`. iOS, iPadOS and tvOS don't show a menu bar, so `CommandMenu`s are dropped at runtime on those platforms.
+
+CommandMenus are declared by overriding `commands()` on your `App` subclass — *not* by including them in `body()`. The macro reads the `commands()` method at compile time and emits a `.commands { … }` modifier on the App's WindowGroup.
+
+```haxe
+class MyApp extends sui.App {
+    public function new() {
+        super();
+        appName = "MyApp";
+        bundleIdentifier = "com.example.myapp";
+    }
+
+    override function body():View {
+        return new Text("Hello");
+    }
+
+    override function commands():Array<CommandMenu> {
+        return [
+            new CommandMenu("Calendar", [
+                new Button("New Event", null, newEventAction)
+                    .keyboardShortcut("n", ["command"]),
+                new Button("Today", null, showTodayAction)
+                    .keyboardShortcut("t", ["command"]),
+            ]),
+            new CommandMenu("View", [
+                new Button("Month", null, showMonthAction)
+                    .keyboardShortcut("1", ["command"]),
+                new Button("Week", null, showWeekAction)
+                    .keyboardShortcut("2", ["command"]),
+                new Button("Day", null, showDayAction)
+                    .keyboardShortcut("3", ["command"]),
+            ]),
+        ];
+    }
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | `String` | Menu title in the menu bar |
+| `content` | `Array<View>` | Buttons (typically with `.keyboardShortcut`) — these become menu items |
+
+Pair `CommandMenu`s with `.keyboardShortcut(...)` on each Button to expose the same shortcut both as a menu item and as a global ⌘ shortcut. See the [Keyboard modifier section](../modifiers.md#keyboard).

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,32 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## Settings (Preferences window)
+
+A separate macOS Preferences window — opened with **⌘,** or the system **App ▸ Preferences…** menu. Declared by overriding `settings()` on your `App` subclass. The returned view is rendered into its own SwiftUI `Settings` scene, alongside the main `WindowGroup`. If you don't override `settings()`, no Settings scene is emitted.
+
+```haxe
+class MyApp extends sui.App {
+    @:state var darkMode:Bool = false;
+    @:state var userName:String = "";
+
+    override function body():View {
+        return new VStack([
+            new Text("Main window"),
+            Text.withState("Dark mode: {darkMode}"),
+        ]);
+    }
+
+    override function settings():View {
+        return new Form([
+            new Toggle("Dark Mode", "darkMode"),
+            new TextField("Display name", "userName"),
+        ]);
+    }
+}
+```
+
+The Settings view shares state with the main `body()` automatically — toggles in Preferences immediately update the main window and vice versa. The macro emits a `SettingsView` Swift struct alongside `ContentView`, both bound to the same `AppState.shared` singleton.
+
+iOS, iPadOS and tvOS ignore the Settings scene at runtime (those platforms route preferences through the system Settings app or an in-app view), so the generated `Settings { … }` block is wrapped in `#if os(macOS)`.

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,20 @@ class App {
         return new View();
     }
 
+    /** Override to attach top-level menus to the macOS menu bar. The
+        returned array is read at compile time by the SwiftGenerator
+        macro and emitted as a `.commands { CommandMenu(…) { … } … }`
+        modifier on the App's WindowGroup. iOS / iPadOS / tvOS
+        ignore the commands at runtime (the menu bar isn't shown).
+
+        Each item inside a `CommandMenu` is typically a `Button` with
+        a `.keyboardShortcut`. See `sui.ui.CommandMenu` for a full
+        example.
+    **/
+    public function commands():Array<sui.ui.CommandMenu> {
+        return [];
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,28 @@ class App {
         return new View();
     }
 
+    /** Override to declare a Settings (Preferences) window — the
+        standard macOS `App ▸ Preferences…` / ⌘, scene. The returned
+        view is rendered into its own SwiftUI `Settings` scene
+        alongside the main WindowGroup; if this is left at the
+        default (a bare `View()`), no Settings scene is emitted.
+
+        ```haxe
+        override function settings():View {
+            return new Form([
+                new Toggle("Dark Mode", "darkMode"),
+                new Picker("Default View", "defaultView", [...]),
+            ]);
+        }
+        ```
+
+        iOS / iPadOS / tvOS ignore the Settings scene at runtime —
+        on those platforms preferences belong in the system Settings
+        bundle or an in-app view. **/
+    public function settings():View {
+        return new View();
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,12 +150,19 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var commandsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "commands") {
+                // Walk `commands()` to find its returned TArrayDecl of
+                // `new CommandMenu(...)` values. Render each via
+                // `viewToSwift` and stitch them into a single
+                // `.commands { … }` block attached to WindowGroup.
+                var expr = field.expr();
+                if (expr != null) commandsSwift = walkCommandsFunc(expr);
             }
         }
 
@@ -174,6 +181,11 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (commandsSwift != "") {
+            appSwift.add("        .commands {\n");
+            appSwift.add(commandsSwift);
+            appSwift.add("        }\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -864,6 +876,72 @@ class SwiftGenerator {
         }
     }
 
+    /** Walk `commands(): Array<CommandMenu>` — find the returned
+        TArrayDecl, render each element via `viewToSwift`, and join
+        with the right indentation for the `.commands { … }` block
+        on the App's WindowGroup.
+
+        Haxe's typer hoists complex sub-expressions into TVar
+        bindings (e.g. inner `new Button(...)` references become
+        TLocal pointing at synthesised vars). `viewToSwift` resolves
+        TLocal through `localBindings`, so we walk the function body
+        ahead of time and collect every TVar's init expression
+        into that map. Without this pass the TLocal refs bubble up
+        as `// [sui] unhandled expression: TLocal` placeholders. **/
+    static function walkCommandsFunc(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "";
+        function collectBindings(e:haxe.macro.Type.TypedExpr):Void {
+            if (e == null) return;
+            switch (e.expr) {
+                case TVar(v, initExpr):
+                    if (initExpr != null) {
+                        localBindings.set(v.id, initExpr);
+                        collectBindings(initExpr);
+                    }
+                case TFunction(f): collectBindings(f.expr);
+                case TBlock(stmts):
+                    for (s in stmts) collectBindings(s);
+                case TReturn(re): collectBindings(re);
+                case TCast(inner, _): collectBindings(inner);
+                case TParenthesis(inner): collectBindings(inner);
+                case TMeta(_, inner): collectBindings(inner);
+                case TArrayDecl(elems):
+                    for (el in elems) collectBindings(el);
+                case TNew(_, _, args):
+                    for (a in args) collectBindings(a);
+                case TCall(_, args):
+                    for (a in args) collectBindings(a);
+                case TArray(arr, idx):
+                    collectBindings(arr);
+                    collectBindings(idx);
+                default:
+            }
+        }
+        collectBindings(expr);
+
+        // Descend through TFunction / TBlock / TReturn to the TArrayDecl.
+        function findArrayDecl(e:haxe.macro.Type.TypedExpr):Null<Array<haxe.macro.Type.TypedExpr>> {
+            if (e == null) return null;
+            switch (e.expr) {
+                case TFunction(f): return findArrayDecl(f.expr);
+                case TBlock(stmts):
+                    if (stmts.length > 0) return findArrayDecl(stmts[stmts.length - 1]);
+                case TReturn(re): return findArrayDecl(re);
+                case TCast(inner, _): return findArrayDecl(inner);
+                case TParenthesis(inner): return findArrayDecl(inner);
+                case TMeta(_, inner): return findArrayDecl(inner);
+                case TArrayDecl(elems): return elems;
+                default:
+            }
+            return null;
+        }
+        var elems = findArrayDecl(expr);
+        if (elems == null || elems.length == 0) return "";
+        var buf = new StringBuf();
+        for (cm in elems) buf.add(viewToSwift(cm, 3));
+        return buf.toString();
+    }
+
     static function viewToSwift(expr:haxe.macro.Type.TypedExpr, indent:Int):String {
         // Unwrap casts, metas, parentheses
         var unwrapped = unwrap(expr);
@@ -1357,6 +1435,27 @@ class SwiftGenerator {
                     buf.add('${pad}Section("${esc(header)}") {\n');
                 else
                     buf.add('${pad}Section {\n');
+                for (child in children)
+                    buf.add(viewToSwift(child, indent + 1));
+                buf.add('${pad}}\n');
+                return buf.toString();
+
+            case "CommandMenu":
+                // Top-level macOS menu-bar menu. Same shape as
+                // `Section` / `Menu`: label string + TArrayDecl of
+                // children. Attached to the App scene by the App.swift
+                // emitter via `.commands { … }`.
+                var label = if (args.length > 0) extractString(args[0]) else null;
+                var children:Array<haxe.macro.Type.TypedExpr> = [];
+                if (args.length > 1) {
+                    var uArg = unwrap(args[1]);
+                    switch (uArg.expr) {
+                        case TArrayDecl(el): children = el;
+                        default:
+                    }
+                }
+                var buf = new StringBuf();
+                buf.add('${pad}CommandMenu("${esc(label != null ? label : "")}") {\n');
                 for (child in children)
                     buf.add(viewToSwift(child, indent + 1));
                 buf.add('${pad}}\n');

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -202,13 +202,26 @@ class SwiftGenerator {
         }
         appSwift.add("        HaxeRuntime.initialize()\n");
         appSwift.add("    }\n\n");
-        appSwift.add("    var body: some Scene {\n");
+        // The `commands` block lives at Scene level, not inside a
+        // View — so `appState.X` references inside StateActions can't
+        // resolve through ContentView's `@Bindable var appState`.
+        // Inject the same declaration into the App struct so the
+        // commands closures see it.
+        var needsAppStateInApp = (commandsSwift != "" || hasSettings)
+            && needsRuntimeBridge && stateDecls.length > 0;
+        if (needsAppStateInApp) {
+            appSwift.add("\n    @Bindable var appState = AppState.shared\n");
+        }
+        appSwift.add("\n    var body: some Scene {\n");
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
         if (commandsSwift != "") {
+            var emitted = needsAppStateInApp
+                ? rewriteStateRefsToAppState(commandsSwift, stateDecls)
+                : commandsSwift;
             appSwift.add("        .commands {\n");
-            appSwift.add(commandsSwift);
+            appSwift.add(emitted);
             appSwift.add("        }\n");
         }
         if (hasSettings) {
@@ -245,52 +258,7 @@ class SwiftGenerator {
         viewSwift.add("    var body: some View {\n");
 
         if (needsRuntimeBridge && stateDecls.length > 0) {
-            // Replace state variable references with appState.name
-            var bodyWithAppState = bodySwift;
-            // Use placeholders to avoid cascading replacements
-            var placeholder = "__APPSTATE__";
-            for (sd in stateDecls) {
-                var n = sd.name;
-                // Replace $name (Swift binding) with $__APPSTATE__name
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "$" + n, "$" + placeholder + n);
-                // Replace \(name) (Swift string interpolation) with \(__APPSTATE__name)
-                bodyWithAppState = StringTools.replace(bodyWithAppState, '\\(' + n + ')', '\\(' + placeholder + n + ')');
-                // Replace {name} in bridge call args with __APPSTATE__interpolation
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "{" + n + "}", '\\(' + placeholder + n + ')');
-                // Replace bare "name = " (assignment in closures) with __APPSTATE__name =
-                bodyWithAppState = StringTools.replace(bodyWithAppState, n + " = ", placeholder + n + " = ");
-                // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
-                // Replace "0..<name.count" — the ForEach iteration header
-                // emits the bare state name, which would otherwise resolve
-                // to an unbound identifier inside ContentView's body when
-                // the state lives on the separate AppState object that the
-                // bridge codepath generates.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
-                // Replace "ForEach(name," — the closure form of ForEach
-                // iterates directly over a state array; without this,
-                // the bare array name would be unbound inside the body
-                // when state lives on the appState bridge object.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "ForEach(" + n + ",", "ForEach(" + placeholder + n + ",");
-                // Replace "(name[" (subscript access from inside string
-                // interpolation: "\(name[i])"). Matched with the leading
-                // paren so we don't accidentally rewrite suffix matches in
-                // longer identifiers, and so we leave existing
-                // "\(__APPSTATE__name[" alone (placeholder already in).
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
-                // Replace "!name[" (logical-not subscript) and " name["
-                // (statement-leading bare reference inside CustomSwift
-                // bodies). Two narrow lookbehinds rather than a generic
-                // `name[` to avoid false-positives where the state name
-                // appears as a suffix of another identifier.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "!" + n + "[", "!" + placeholder + n + "[");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, " " + n + "[", " " + placeholder + n + "[");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "=" + n + "[", "=" + placeholder + n + "[");
-            }
-            // Now resolve all placeholders to "appState."
-            bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");
-            viewSwift.add(bodyWithAppState);
+            viewSwift.add(rewriteStateRefsToAppState(bodySwift, stateDecls));
         } else {
             viewSwift.add(bodySwift);
         }
@@ -313,20 +281,7 @@ class SwiftGenerator {
             }
             viewSwift.add("    var body: some View {\n");
             if (needsRuntimeBridge && stateDecls.length > 0) {
-                // Reuse the same appState-prefix pass as ContentView.
-                var s = settingsSwift;
-                var placeholder = "__APPSTATE__";
-                for (sd in stateDecls) {
-                    var n = sd.name;
-                    s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
-                    s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
-                    s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
-                    s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
-                    s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
-                    s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
-                }
-                s = StringTools.replace(s, placeholder, "appState.");
-                viewSwift.add(s);
+                viewSwift.add(rewriteStateRefsToAppState(settingsSwift, stateDecls));
             } else {
                 viewSwift.add(settingsSwift);
             }
@@ -402,6 +357,48 @@ class SwiftGenerator {
                 }
             }
         }
+    }
+
+    /** Rewrite the bare state names produced by `viewToSwift` /
+        StateAction emission so they target the bridged `appState.X`
+        object. The codepath that emits Swift assumes everything will
+        be hoisted under a `@Bindable var appState = AppState.shared`
+        — but the emitter doesn't know that yet, so we patch the
+        identifiers in a single textual pass. Run this on every
+        chunk that lives in a struct holding `appState`: the
+        ContentView body, the SettingsView body, and (for
+        scene-level constructs like `.commands { … }`) the App
+        struct's body. **/
+    static function rewriteStateRefsToAppState(s:String, stateDecls:Array<{name:String, swiftType:String, defaultValue:String}>):String {
+        var placeholder = "__APPSTATE__";
+        for (sd in stateDecls) {
+            var n = sd.name;
+            // `$name` (Swift binding)
+            s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
+            // `\(name)` (Swift string interpolation)
+            s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
+            // `{name}` (bridge call argument templates)
+            s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
+            // `name = ` (assignment inside closures)
+            s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
+            // `if name ` / `if name\n` (ConditionalView boolean)
+            s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
+            s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
+            // `0..<name.count` (ForEach iteration header)
+            s = StringTools.replace(s, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
+            // `ForEach(name,` (closure-form ForEach over a state array)
+            s = StringTools.replace(s, "ForEach(" + n + ",", "ForEach(" + placeholder + n + ",");
+            // `(name[` `!name[` ` name[` `=name[` (subscript-access
+            // shapes that show up inside CustomSwift / interpolation
+            // bodies). Each lookbehind is narrow enough to avoid
+            // matching a state name that happens to be a suffix of a
+            // longer identifier.
+            s = StringTools.replace(s, "(" + n + "[", "(" + placeholder + n + "[");
+            s = StringTools.replace(s, "!" + n + "[", "!" + placeholder + n + "[");
+            s = StringTools.replace(s, " " + n + "[", " " + placeholder + n + "[");
+            s = StringTools.replace(s, "=" + n + "[", "=" + placeholder + n + "[");
+        }
+        return StringTools.replace(s, placeholder, "appState.");
     }
 
     /** Generate an @Observable AppState class for bridged state management. **/

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,14 +150,29 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var settingsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "settings") {
+                var expr = field.expr();
+                if (expr != null) settingsSwift = walkFunc(expr, 2);
             }
         }
+        // The default `settings()` returns `new View()`, which
+        // `viewToSwift` renders as a "Unknown view" placeholder
+        // comment. Treat that as "user didn't override" and skip
+        // emitting the Settings scene altogether.
+        var hasSettings = settingsSwift != "" && settingsSwift.indexOf("Unknown view") == -1;
+        // The Settings scene only makes sense if its preferences
+        // share state with the rest of the app — `Toggle("Dark Mode",
+        // "darkMode")` in Settings must read/write the same value
+        // ContentView observes. Force the bridged AppState path so
+        // both view structs reference `AppState.shared` rather than
+        // each carrying its own private `@State` copies.
+        if (hasSettings) needsRuntimeBridge = true;
 
         // 5. Emit App.swift (after needsRuntimeBridge is finalized)
         var appSwift = new StringBuf();
@@ -174,6 +189,13 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (hasSettings) {
+            appSwift.add("        #if os(macOS)\n");
+            appSwift.add("        Settings {\n");
+            appSwift.add("            SettingsView()\n");
+            appSwift.add("        }\n");
+            appSwift.add("        #endif\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -228,6 +250,42 @@ class SwiftGenerator {
 
         viewSwift.add("    }\n");
         viewSwift.add("}\n");
+
+        // 5b. Optionally emit a SettingsView struct alongside ContentView.
+        //     Same `@Bindable var appState` (or `@State`s) wiring so it
+        //     can read/write the same app-wide state.
+        if (hasSettings) {
+            viewSwift.add("\n");
+            viewSwift.add("struct SettingsView: View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                viewSwift.add("    @Bindable var appState = AppState.shared\n\n");
+            } else {
+                for (sd in stateDecls)
+                    viewSwift.add('    @State private var ${sd.name}: ${sd.swiftType} = ${sd.defaultValue}\n');
+                if (stateDecls.length > 0) viewSwift.add("\n");
+            }
+            viewSwift.add("    var body: some View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                // Reuse the same appState-prefix pass as ContentView.
+                var s = settingsSwift;
+                var placeholder = "__APPSTATE__";
+                for (sd in stateDecls) {
+                    var n = sd.name;
+                    s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
+                    s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
+                    s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
+                    s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
+                }
+                s = StringTools.replace(s, placeholder, "appState.");
+                viewSwift.add(s);
+            } else {
+                viewSwift.add(settingsSwift);
+            }
+            viewSwift.add("    }\n");
+            viewSwift.add("}\n");
+        }
 
         // 6. Generate model structs for Observable subclasses used by this app
         var modelSwift = new StringBuf();

--- a/src/sui/ui/CommandMenu.hx
+++ b/src/sui/ui/CommandMenu.hx
@@ -1,0 +1,43 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A top-level macOS menu-bar menu — appears next to File / Edit / View
+    / Help in the system menu bar. Maps to SwiftUI's `CommandMenu` and
+    is attached to the App scene via the `commands()` override.
+
+    Items are typically `Button`s (with `.keyboardShortcut(...)` so each
+    has an associated ⌘-shortcut) and `Divider`s between groups.
+    Nested `Menu`s aren't supported by `CommandMenu` directly — use
+    sub-`CommandMenu`s instead.
+
+    ```haxe
+    class MyApp extends sui.App {
+        override function commands():Array<CommandMenu> {
+            return [
+                new CommandMenu("Calendar", [
+                    new Button("New Event", null, newEventAction)
+                        .keyboardShortcut("n", ["command"]),
+                    new Button("Today", null, showTodayAction)
+                        .keyboardShortcut("t", ["command"]),
+                ]),
+            ];
+        }
+    }
+    ```
+
+    On iOS / iPadOS / tvOS the menu bar isn't shown, so `CommandMenu`s
+    are silently dropped by SwiftUI on those platforms.
+**/
+@:swiftView("CommandMenu")
+class CommandMenu extends View {
+    public var label:String;
+
+    public function new(@:swiftLabel("_") label:String, content:Array<View>) {
+        super();
+        this.viewType = "CommandMenu";
+        this.label = label;
+        this.children = content;
+    }
+}


### PR DESCRIPTION
`CommandMenu` buttons declared via `App.commands()` are emitted into the App struct's `.commands { … }` block — at the Scene level, not inside `ContentView`. The bodyWithAppState pass that rewrites bare state names to `appState.X` was wired only for ContentView and SettingsView, so the commands block emitted unbound identifiers like:

```swift
Button("Nouvel événement") {
    loginStatus = ""   // ← unbound, never refers to AppState.shared.loginStatus
}
```

…which fails to compile.

## What this PR does

1. Extracts the inline rewrite block into a reusable helper, `rewriteStateRefsToAppState(s, stateDecls)`. ContentView body and SettingsView body both call it; one source of truth for the pass.
2. Applies the helper to the new commands codepath.
3. Injects `@Bindable var appState = AppState.shared` into the App struct when either `commands()` or `settings()` is overridden and the app uses the bridged AppState. Without this, the rewritten `appState.X` references in `.commands` would themselves be unbound (the App struct doesn't otherwise reference AppState).

## Stack

Builds on `feat/command-menu` + `feat/settings-scene` — merge those first, then this rebases cleanly onto `main`.

## Verification

Tested via the calendar-mac client which has a 4-item `CommandMenu` with `StateAction.BridgeCallLoading` actions; pre-fix the Swift compile failed with `cannot find 'loginStatus' in scope`, post-fix the menu and global keyboard shortcuts work.