### PR TITLE
Color(suiHex:): accept 8-digit #RRGGBBAA with alpha channel

### DIFF
--- a/runtime/swift/ViewBridge.swift
+++ b/runtime/swift/ViewBridge.swift
@@ -12,13 +12,16 @@ extension HaxeView {
     func haxeOnDisappear() {}
 }
 
-/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB" or 3-digit shorthand.
-/// Returns `nil` for invalid input so call sites can fall back via the
-/// nil-coalescing operator: `Color(suiHex: appState.calendarColor) ?? .primary`.
+/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB", 3-digit shorthand
+/// `#RGB`, or 8-digit `#RRGGBBAA` with an alpha channel. Use the
+/// alpha form (`"#00000000"`) when you want a state-driven colour
+/// that conditionally renders nothing — empty/invalid strings fall
+/// back via the nil-coalescing operator the macro emits:
+/// `Color(suiHex: appState.x) ?? .primary`.
 ///
-/// Used by sui's foregroundHex / backgroundHex modifiers — codegen emits
-/// the optional-fallback expression so user state values that aren't
-/// well-formed hex don't crash the SwiftUI body.
+/// Used by sui's foregroundHex / backgroundHex modifiers — codegen
+/// emits the optional-fallback expression so user state values that
+/// aren't well-formed hex don't crash the SwiftUI body.
 extension Color {
     init?(suiHex: String) {
         var s = suiHex.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -26,12 +29,21 @@ extension Color {
         if s.count == 3 {
             s = s.map { "\($0)\($0)" }.joined()
         }
-        guard s.count == 6,
-              let v = UInt32(s, radix: 16)
+        let len = s.count
+        guard (len == 6 || len == 8),
+              let v = UInt64(s, radix: 16)
         else { return nil }
-        let r = Double((v >> 16) & 0xFF) / 255.0
-        let g = Double((v >> 8) & 0xFF) / 255.0
-        let b = Double(v & 0xFF) / 255.0
-        self.init(red: r, green: g, blue: b)
+        if len == 8 {
+            let r = Double((v >> 24) & 0xFF) / 255.0
+            let g = Double((v >> 16) & 0xFF) / 255.0
+            let b = Double((v >> 8) & 0xFF) / 255.0
+            let a = Double(v & 0xFF) / 255.0
+            self.init(red: r, green: g, blue: b, opacity: a)
+        } else {
+            let r = Double((v >> 16) & 0xFF) / 255.0
+            let g = Double((v >> 8) & 0xFF) / 255.0
+            let b = Double(v & 0xFF) / 255.0
+            self.init(red: r, green: g, blue: b)
+        }
     }
 }


### PR DESCRIPTION
The 6-digit form has no way to express partial opacity, so any state-driven background or foreground that needed to fade in/out (a "now" line that hides when the visible day isn't today, a tinted block whose intensity varies, …) had to fall through `?? Color.primary` and paint a hard black on every empty value.

8-digit `#RRGGBBAA` parses identically except for the trailing alpha byte, so the existing call sites (which all pass 6-digit hex) keep working and new ones can use `"#00000000"` (fully transparent) or `"#ff3b30aa"` (~67% red), etc.

## Stack

Builds on `feat/foreground-hex-from-state` — `Color(suiHex:)` itself is added there. Merge that one first; this PR will then rebase cleanly onto `main`.