### PR TITLE
StateOr: accept String as a legacy stringly-typed escape hatch

### DIFF
--- a/src/sui/state/StateOr.hx
+++ b/src/sui/state/StateOr.hx
@@ -21,4 +21,13 @@ abstract StateOr<T>(Dynamic) {
     @:from public static inline function fromState<T>(s:State<T>):StateOr<T> {
         return cast s;
     }
+
+    /** Legacy stringly-typed escape hatch — accepts an expression
+        the macro forwards into Swift verbatim (e.g.
+        `"dayEventStartFracs[i]"` to subscript an array state by the
+        enclosing `ForEach` index). Prefer the typed `State<T>` form
+        when the binding doesn't need an index. **/
+    @:from public static inline function fromString(s:String):StateOr<Float> {
+        return cast s;
+    }
 }


### PR DESCRIPTION
Modifiers like `.offset(x, y)`, `.scaleEffect(s)`, and the new `.proportionalOffset(xFrac, yFrac)` typically want a literal `Float` or a `State<Float>`. But inside a `ForEach` loop, the natural binding is an array subscript bound to the lambda index, e.g. `"dayEventStartFracs[i]"`. The macro's existing `TString → __APPSTATE__` placeholder pass already rewrites that into a working `appState.dayEventStartFracs[i]` Swift expression — but the type system was rejecting the String before it could reach the modifier.

Add a `@:from String` conversion so legacy stringly-typed call sites keep compiling. Typed `State<T>` paths remain the recommended form for binding to a known state variable.

## Use cases

Looks unchanged for typed call sites:
```haxe
.proportionalOffset(0, nowMinuteFrac)      // State<Float>
.scaleEffect(1.5)                           // Float literal
.offset(scaleX, scaleY)                     // State<Float>s
```

Newly accepted via the String form:
```haxe
new ForEach(dayEventTitles, "i",
  myView.proportionalOffset("dayEventX[i]", "dayEventY[i]")
)
```

The pre-existing pattern-rewriter handles the array-subscript shape in the macro pass, so the emitted Swift is `proxy.size.width * (appState.dayEventX[i])`.