### PR TITLE
GeometryReader + proportional layout + IntervalLoop + alignment emission

### DIFF
--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -153,6 +153,7 @@ new VStack([...])
 |----------|-----------|-------------|
 | `.onTapGesture(action)` | `action: StateAction` | Runs a StateAction when tapped |
 | `.onLongPressGesture(action)` | `action: StateAction` | Runs a StateAction on long press |
+| `.onKeyPress(key, action)` | `key: String`, `action: StateAction` | Runs a StateAction when the named key is pressed while the view (or a descendant) has focus. |
 
 ```haxe
 new Text("Tap me")
@@ -160,7 +161,14 @@ new Text("Tap me")
 
 new Text("Hold me")
     .onLongPressGesture(showMenu.tog())
+
+// Key press handlers — same key-naming as keyboardShortcut
+new VStack([...])
+    .onKeyPress("escape", dismissAction)
+    .onKeyPress("right", nextAction)
 ```
+
+`onKeyPress` uses the same `key` strings as `.keyboardShortcut` — single chars or named special keys: `"return"`, `"escape"`, `"delete"`, `"tab"`, `"space"`, `"left"` / `"right"` / `"up"` / `"down"`, `"home"`, `"end"`, `"pageup"` / `"pagedown"`. The action runs only when the view (or a descendant) has keyboard focus; the handler returns `.handled` so SwiftUI stops bubbling the event up the focus chain.
 
 ## Lifecycle
 

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -162,6 +162,57 @@ new Text("Hold me")
     .onLongPressGesture(showMenu.tog())
 ```
 
+## Keyboard
+
+| Modifier | Parameters | Description |
+|----------|-----------|-------------|
+| `.keyboardShortcut(key, modifiers)` | `key: String`, `modifiers: Array<String>` (optional) | Bind a keyboard shortcut to a view (typically a Button). Maps to SwiftUI's `.keyboardShortcut(_:, modifiers:)`. |
+
+**`key`** is either a single character (`"n"`, `"s"`, `","`) or one of the named special keys:
+
+| Name | Swift `KeyEquivalent` |
+|------|-----------------------|
+| `"return"` | `.return` |
+| `"escape"` | `.escape` |
+| `"delete"` / `"backspace"` | `.delete` |
+| `"tab"` | `.tab` |
+| `"space"` | `.space` |
+| `"left"` | `.leftArrow` |
+| `"right"` | `.rightArrow` |
+| `"up"` | `.upArrow` |
+| `"down"` | `.downArrow` |
+| `"home"` / `"end"` | `.home` / `.end` |
+| `"pageup"` / `"pagedown"` | `.pageUp` / `.pageDown` |
+
+**`modifiers`** is any combination (order doesn't matter) of:
+
+| Name | Swift `EventModifiers` |
+|------|------------------------|
+| `"command"` / `"cmd"` | `.command` |
+| `"option"` / `"alt"` | `.option` |
+| `"control"` / `"ctrl"` | `.control` |
+| `"shift"` | `.shift` |
+| `"capslock"` | `.capsLock` |
+
+Omitting `modifiers` (or passing an empty array) binds the bare key — useful for `"escape"`, arrow keys, etc.
+
+```haxe
+new Button("New Event", null, openNewEventAction)
+    .keyboardShortcut("n", ["command"]);          // ⌘N
+
+new Button("Today", null, showTodayAction)
+    .keyboardShortcut("t", ["command"]);          // ⌘T
+
+new Button("Close", null, dismissAction)
+    .keyboardShortcut("escape");                  // Esc
+
+new Button("Next", null, nextAction)
+    .keyboardShortcut("right", ["command"]);      // ⌘→
+
+new Button("Save As…", null, saveAsAction)
+    .keyboardShortcut("s", ["command", "shift"]); // ⇧⌘S
+```
+
 ## Lifecycle
 
 | Modifier | Parameters | Description |

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -139,6 +139,19 @@ new Image("photo").blur(blurAmount)
 | `.alert(title, binding, message)` | `title: String`, `binding: State<Bool>`, `message: String` | Alert dialog |
 | `.confirmationDialog(title, binding, content)` | `title: String`, `binding: State<Bool>`, `content: View` | Action sheet |
 | `.contextMenu(content)` | `content: View` | Long-press context menu |
+| `.inspector(binding, content)` | `binding: State<Bool>`, `content: View` | macOS trailing inspector pane — slides out from the right edge when the binding is `true`. Standard pattern for "details about the current selection". |
+
+```haxe
+@:state var showInspector:Bool = false;
+
+new VStack([...])
+    .inspector(showInspector, new VStack([
+        new Text("Details"),
+        Text.withState("Selected: {selectedItem}"),
+    ]))
+```
+
+The Inspector is the macOS-native alternative to a sheet for showing supplementary info — Pages, Numbers, Xcode, Final Cut all use this pattern. On iOS it falls back to a popover.
 
 ```haxe
 new VStack([...])

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -188,6 +188,7 @@ new VStack([...])
 
 | Modifier | Parameters | Description |
 |----------|-----------|-------------|
+| `.help(text)` | `text: String` | Tooltip shown on hover on macOS, accessibility hint on iOS. |
 | `.accessibilityLabel(label)` | `label: String` | Screen reader label |
 
 ## Animation

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -56,8 +56,21 @@ new Text("Styled")
 |----------|-----------|-------------|
 | `.foregroundColor(color)` | `color: ColorValue` | Text/icon color |
 | `.background(color)` | `color: ColorValue` | Background color |
+| `.backgroundMaterial(style)` | `style: MaterialStyle` | Translucent frosted-glass background (`.regularMaterial`, etc.) — adapts to dark/light, picks up content behind. |
 | `.opacity(value)` | `value: Float` | Opacity (0.0 to 1.0) |
 | `.tint(color)` | `color: ColorValue` | Accent/tint color |
+
+**MaterialStyle values:** `Regular`, `Thin`, `UltraThin`, `Thick`, `UltraThick`, `Bar`
+
+The `.backgroundMaterial` modifier gives you the translucent frosted-glass treatment that macOS uses on sidebars, popovers and toolbars. Each style is a different thickness — `Thin` lets more of the underlying content through, `Thick` is more opaque. `Bar` is the toolbar-specific variant.
+
+```haxe
+new VStack([...])
+    .backgroundMaterial(MaterialStyle.Regular)
+
+new VStack([...])
+    .backgroundMaterial(MaterialStyle.Bar)
+```
 
 **ColorValue values:** `Primary`, `Secondary`, `Accent`, `Red`, `Orange`, `Yellow`, `Green`, `Blue`, `Purple`, `Pink`, `White`, `Black`, `Gray`, `Clear`, `Custom(hex)`
 

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -181,7 +181,8 @@ new VStack([...])
     .onKeyPress("right", nextAction)
 ```
 
-<<<<<<< HEAD
+`onKeyPress` uses the same `key` strings as `.keyboardShortcut` — see the [Keyboard section below](#keyboard) for the full list. The action runs only when the view (or a descendant) has keyboard focus; the handler returns `.handled` so SwiftUI stops bubbling the event up the focus chain.
+
 ## Keyboard
 
 | Modifier | Parameters | Description |
@@ -232,9 +233,6 @@ new Button("Next", null, nextAction)
 new Button("Save As…", null, saveAsAction)
     .keyboardShortcut("s", ["command", "shift"]); // ⇧⌘S
 ```
-=======
-`onKeyPress` uses the same `key` strings as `.keyboardShortcut` — single chars or named special keys: `"return"`, `"escape"`, `"delete"`, `"tab"`, `"space"`, `"left"` / `"right"` / `"up"` / `"down"`, `"home"`, `"end"`, `"pageup"` / `"pagedown"`. The action runs only when the view (or a descendant) has keyboard focus; the handler returns `.handled` so SwiftUI stops bubbling the event up the focus chain.
->>>>>>> feat/on-key-press
 
 ## Lifecycle
 

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -153,6 +153,7 @@ new Image("photo").blur(blurAmount)
 | `.confirmationDialog(title, binding, content)` | `title: String`, `binding: State<Bool>`, `content: View` | Action sheet |
 | `.contextMenu(content)` | `content: View` | Long-press context menu |
 | `.inspector(binding, content)` | `binding: State<Bool>`, `content: View` | macOS trailing inspector pane — slides out from the right edge when the binding is `true`. Standard pattern for "details about the current selection". |
+| `.inspectorColumnWidth(min, ideal, max)` | `min: Float`, `ideal: Float`, `max: Float` | Width hint for the Inspector column. SwiftUI defaults to a narrow track that can shrink further on window resize — set explicit bounds here whenever the inspector content has its own intrinsic width (forms, multi-column lists, etc.). Apply on the same view that owns `.inspector(...)`. |
 
 ```haxe
 @:state var showInspector:Bool = false;
@@ -162,9 +163,12 @@ new VStack([...])
         new Text("Details"),
         Text.withState("Selected: {selectedItem}"),
     ]))
+    .inspectorColumnWidth(360, 480, 720)
 ```
 
 The Inspector is the macOS-native alternative to a sheet for showing supplementary info — Pages, Numbers, Xcode, Final Cut all use this pattern. On iOS it falls back to a popover.
+
+`.inspectorColumnWidth(min, ideal, max)` is almost always wanted alongside `.inspector(...)` — without it the column lands at SwiftUI's default (~250pt) and can shrink further when the user resizes the window, which is too tight for anything other than a key/value detail list.
 
 ```haxe
 new VStack([...])

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,51 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## CommandMenu (macOS menu bar)
+
+A top-level menu in the macOS menu bar — appears next to **File / Edit / View / Help**. Maps to SwiftUI's `CommandMenu`. iOS, iPadOS and tvOS don't show a menu bar, so `CommandMenu`s are dropped at runtime on those platforms.
+
+CommandMenus are declared by overriding `commands()` on your `App` subclass — *not* by including them in `body()`. The macro reads the `commands()` method at compile time and emits a `.commands { … }` modifier on the App's WindowGroup.
+
+```haxe
+class MyApp extends sui.App {
+    public function new() {
+        super();
+        appName = "MyApp";
+        bundleIdentifier = "com.example.myapp";
+    }
+
+    override function body():View {
+        return new Text("Hello");
+    }
+
+    override function commands():Array<CommandMenu> {
+        return [
+            new CommandMenu("Calendar", [
+                new Button("New Event", null, newEventAction)
+                    .keyboardShortcut("n", ["command"]),
+                new Button("Today", null, showTodayAction)
+                    .keyboardShortcut("t", ["command"]),
+            ]),
+            new CommandMenu("View", [
+                new Button("Month", null, showMonthAction)
+                    .keyboardShortcut("1", ["command"]),
+                new Button("Week", null, showWeekAction)
+                    .keyboardShortcut("2", ["command"]),
+                new Button("Day", null, showDayAction)
+                    .keyboardShortcut("3", ["command"]),
+            ]),
+        ];
+    }
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | `String` | Menu title in the menu bar |
+| `content` | `Array<View>` | Buttons (typically with `.keyboardShortcut`) — these become menu items |
+
+Pair `CommandMenu`s with `.keyboardShortcut(...)` on each Button to expose the same shortcut both as a menu item and as a global ⌘ shortcut. See the [Keyboard modifier section](../modifiers.md#keyboard).

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,28 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## Menu
+
+A drop-down menu containing buttons or nested `Menu`s. Maps to SwiftUI's `Menu`. The typical use case is a toolbar dropdown — clicking the label opens a popover with the actions. On macOS it adopts the system `NSMenu` look; on iOS it's a popover sheet.
+
+```haxe
+new Menu("Actions", [
+    new Button("New", null, newAction),
+    new Button("Open…", null, openAction),
+    new Menu("Recent", [
+        new Button("File 1", null, openFile1Action),
+        new Button("File 2", null, openFile2Action),
+    ]),
+    new Button("Delete", null, deleteAction),
+])
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | `String` | The text shown on the menu trigger |
+| `content` | `Array<View>` | The menu items — typically `Button`s or nested `Menu`s |
+
+Menus can be nested arbitrarily for sub-menus.

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -145,3 +145,32 @@ new Picker("Color", "selectedColor", [
 | `label` | `String` | Picker label |
 | `selectionBinding` | `String` | Name of the `@State var` to bind to |
 | `content` | `Array<View>` | Options (typically Text views) |
+
+## Settings (Preferences window)
+
+A separate macOS Preferences window — opened with **⌘,** or the system **App ▸ Preferences…** menu. Declared by overriding `settings()` on your `App` subclass. The returned view is rendered into its own SwiftUI `Settings` scene, alongside the main `WindowGroup`. If you don't override `settings()`, no Settings scene is emitted.
+
+```haxe
+class MyApp extends sui.App {
+    @:state var darkMode:Bool = false;
+    @:state var userName:String = "";
+
+    override function body():View {
+        return new VStack([
+            new Text("Main window"),
+            Text.withState("Dark mode: {darkMode}"),
+        ]);
+    }
+
+    override function settings():View {
+        return new Form([
+            new Toggle("Dark Mode", "darkMode"),
+            new TextField("Display name", "userName"),
+        ]);
+    }
+}
+```
+
+The Settings view shares state with the main `body()` automatically — toggles in Preferences immediately update the main window and vice versa. The macro emits a `SettingsView` Swift struct alongside `ContentView`, both bound to the same `AppState.shared` singleton.
+
+iOS, iPadOS and tvOS ignore the Settings scene at runtime (those platforms route preferences through the system Settings app or an in-app view), so the generated `Settings { … }` block is wrapped in `#if os(macOS)`.

--- a/docs/views/controls.md
+++ b/docs/views/controls.md
@@ -126,6 +126,25 @@ new Slider("volume", 0.0, 100.0)
 | `rangeMin` | `Float` | Minimum value |
 | `rangeMax` | `Float` | Maximum value |
 
+## ShareLink
+
+A button that triggers the system share sheet — macOS Share menu on Mac, `UIActivityViewController` on iOS / iPadOS / visionOS. Maps to SwiftUI's `ShareLink(item:)`.
+
+```haxe
+// Default UI — system share-arrow icon
+new ShareLink("https://example.com")
+
+// Custom label
+new ShareLink("https://example.com", "Share this link")
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `item` | `String` | The thing being shared. SwiftUI auto-detects URLs vs plain text from the string. |
+| `label` | `String` (optional) | Custom label text. Without it, the default share-arrow icon is shown. |
+
 ## Picker
 
 A selection control bound to a `@State` variable.

--- a/docs/views/layout.md
+++ b/docs/views/layout.md
@@ -92,6 +92,30 @@ new VStack([
 |-----------|------|---------|-------------|
 | `minLength` | `Float` | `null` | Minimum size |
 
+## Shape primitives
+
+`Rectangle`, `Circle`, `Capsule`, `Ellipse` are zero-arg shape views that map to their SwiftUI equivalents. Like all SwiftUI shapes, they have no intrinsic size — give them one via `.frame(...)` (or rely on the parent layout to size them). Fill with `.foregroundColor(...)` / `.foregroundHex(...)`.
+
+```haxe
+new Rectangle()
+    .frame(100, 50)
+    .foregroundColor(ColorValue.Blue)
+
+new Circle()
+    .frame(20, 20)
+    .foregroundColor(ColorValue.Red)
+
+new Capsule()
+    .frame(100, 24)
+    .foregroundColor(ColorValue.Accent)
+
+new Ellipse()
+    .frame(100, 50)
+    .foregroundColor(ColorValue.Purple)
+```
+
+Useful as drawing primitives, decoration, overlays, and for chip-style backgrounds where a plain `cornerRadius` isn't enough. For more complex curves use `Path` (not yet wrapped) via `CustomSwift`.
+
 ## ScrollView
 
 Wraps content in a scrollable container.

--- a/docs/views/layout.md
+++ b/docs/views/layout.md
@@ -92,6 +92,38 @@ new VStack([
 |-----------|------|---------|-------------|
 | `minLength` | `Float` | `null` | Minimum size |
 
+## Gradients
+
+Three gradient views — `LinearGradient`, `RadialGradient`, `AngularGradient` — map to their SwiftUI equivalents. Like shapes, they have no intrinsic size; use `.frame(...)` or place them as a `.background(...)` overlay.
+
+```haxe
+new LinearGradient(
+    [ColorValue.Blue, ColorValue.Purple],
+    "top", "bottom"
+)
+
+new RadialGradient(
+    [ColorValue.Yellow, ColorValue.Red],
+    "center", 0, 100
+)
+
+new AngularGradient(
+    [ColorValue.Red, ColorValue.Orange, ColorValue.Yellow,
+     ColorValue.Green, ColorValue.Blue, ColorValue.Purple],
+    "center"
+)
+```
+
+Generates:
+
+```swift
+LinearGradient(colors: [.blue, .purple], startPoint: .top, endPoint: .bottom)
+RadialGradient(colors: [.yellow, .red], center: .center, startRadius: 0, endRadius: 100)
+AngularGradient(colors: [.red, .orange, .yellow, .green, .blue, .purple], center: .center)
+```
+
+**Unit-point strings** (start/end/center): `"top"`, `"bottom"`, `"leading"`, `"trailing"`, `"topLeading"`, `"topTrailing"`, `"bottomLeading"`, `"bottomTrailing"`, `"center"`.
+
 ## ScrollView
 
 Wraps content in a scrollable container.

--- a/examples/closure-foreach/build.hxml
+++ b/examples/closure-foreach/build.hxml
@@ -1,0 +1,6 @@
+-cp src
+-cp ../../src
+-lib hxcpp
+--macro sui.macros.SwiftGenerator.register()
+-main ClosureForEachApp
+-cpp build/cpp

--- a/examples/closure-foreach/src/ClosureForEachApp.hx
+++ b/examples/closure-foreach/src/ClosureForEachApp.hx
@@ -1,0 +1,46 @@
+import sui.App;
+import sui.View;
+import sui.ui.*;
+import sui.state.State;
+
+/**
+    Demonstrates the closure form of `ForEach`.
+
+    The iteration variable is a real Haxe value bound by the lambda,
+    so references to it inside child views are checked by the Haxe
+    compiler and compiled to the matching Swift expression — no more
+    `"name[i]"` strings hand-spliced into modifiers.
+**/
+class ClosureForEachApp extends App {
+    static function main() {}
+
+    @:state var colors:Array<String> = ["red", "green", "blue", "yellow"];
+    @:state var selected:String = "red";
+
+    public function new() {
+        super();
+        appName = "ClosureForEach";
+        bundleIdentifier = "com.sui.closureforeach";
+    }
+
+    override function body():View {
+        return new VStack([
+            new Text("Closure-form ForEach demo")
+                .font(FontStyle.Title)
+                .padding(),
+
+            // Closure form: `color` is a Haxe-typed iteration variable.
+            // Inside the body, `new Text(color)` becomes
+            //   Text("\(appState.colors[color])")
+            // and `.tag(color)` becomes
+            //   .tag(appState.colors[color])
+            new Picker("Pick a color", "selected", [
+                new ForEach(colors, color ->
+                    new Text(color).tag(color)
+                )
+            ]),
+
+            new Spacer()
+        ]).padding();
+    }
+}

--- a/examples/closure-foreach/sui.json
+++ b/examples/closure-foreach/sui.json
@@ -1,0 +1,5 @@
+{
+    "appName": "ClosureForEach",
+    "bundleIdentifier": "com.sui.closureforeach",
+    "bundleIdPrefix": "com.sui"
+}

--- a/runtime/swift/ViewBridge.swift
+++ b/runtime/swift/ViewBridge.swift
@@ -11,3 +11,27 @@ extension HaxeView {
     func haxeOnAppear() {}
     func haxeOnDisappear() {}
 }
+
+/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB" or 3-digit shorthand.
+/// Returns `nil` for invalid input so call sites can fall back via the
+/// nil-coalescing operator: `Color(suiHex: appState.calendarColor) ?? .primary`.
+///
+/// Used by sui's foregroundHex / backgroundHex modifiers — codegen emits
+/// the optional-fallback expression so user state values that aren't
+/// well-formed hex don't crash the SwiftUI body.
+extension Color {
+    init?(suiHex: String) {
+        var s = suiHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        if s.count == 3 {
+            s = s.map { "\($0)\($0)" }.joined()
+        }
+        guard s.count == 6,
+              let v = UInt32(s, radix: 16)
+        else { return nil }
+        let r = Double((v >> 16) & 0xFF) / 255.0
+        let g = Double((v >> 8) & 0xFF) / 255.0
+        let b = Double(v & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/runtime/swift/ViewBridge.swift
+++ b/runtime/swift/ViewBridge.swift
@@ -12,13 +12,16 @@ extension HaxeView {
     func haxeOnDisappear() {}
 }
 
-/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB" or 3-digit shorthand.
-/// Returns `nil` for invalid input so call sites can fall back via the
-/// nil-coalescing operator: `Color(suiHex: appState.calendarColor) ?? .primary`.
+/// `Color(suiHex:)` — parses "#RRGGBB", "RRGGBB", 3-digit shorthand
+/// `#RGB`, or 8-digit `#RRGGBBAA` with an alpha channel. Use the
+/// alpha form (`"#00000000"`) when you want a state-driven colour
+/// that conditionally renders nothing — empty/invalid strings fall
+/// back via the nil-coalescing operator the macro emits:
+/// `Color(suiHex: appState.x) ?? .primary`.
 ///
-/// Used by sui's foregroundHex / backgroundHex modifiers — codegen emits
-/// the optional-fallback expression so user state values that aren't
-/// well-formed hex don't crash the SwiftUI body.
+/// Used by sui's foregroundHex / backgroundHex modifiers — codegen
+/// emits the optional-fallback expression so user state values that
+/// aren't well-formed hex don't crash the SwiftUI body.
 extension Color {
     init?(suiHex: String) {
         var s = suiHex.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -26,12 +29,21 @@ extension Color {
         if s.count == 3 {
             s = s.map { "\($0)\($0)" }.joined()
         }
-        guard s.count == 6,
-              let v = UInt32(s, radix: 16)
+        let len = s.count
+        guard (len == 6 || len == 8),
+              let v = UInt64(s, radix: 16)
         else { return nil }
-        let r = Double((v >> 16) & 0xFF) / 255.0
-        let g = Double((v >> 8) & 0xFF) / 255.0
-        let b = Double(v & 0xFF) / 255.0
-        self.init(red: r, green: g, blue: b)
+        if len == 8 {
+            let r = Double((v >> 24) & 0xFF) / 255.0
+            let g = Double((v >> 16) & 0xFF) / 255.0
+            let b = Double((v >> 8) & 0xFF) / 255.0
+            let a = Double(v & 0xFF) / 255.0
+            self.init(red: r, green: g, blue: b, opacity: a)
+        } else {
+            let r = Double((v >> 16) & 0xFF) / 255.0
+            let g = Double((v >> 8) & 0xFF) / 255.0
+            let b = Double(v & 0xFF) / 255.0
+            self.init(red: r, green: g, blue: b)
+        }
     }
 }

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,20 @@ class App {
         return new View();
     }
 
+    /** Override to attach top-level menus to the macOS menu bar. The
+        returned array is read at compile time by the SwiftGenerator
+        macro and emitted as a `.commands { CommandMenu(…) { … } … }`
+        modifier on the App's WindowGroup. iOS / iPadOS / tvOS
+        ignore the commands at runtime (the menu bar isn't shown).
+
+        Each item inside a `CommandMenu` is typically a `Button` with
+        a `.keyboardShortcut`. See `sui.ui.CommandMenu` for a full
+        example.
+    **/
+    public function commands():Array<sui.ui.CommandMenu> {
+        return [];
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,6 +28,28 @@ class App {
         return new View();
     }
 
+    /** Override to declare a Settings (Preferences) window — the
+        standard macOS `App ▸ Preferences…` / ⌘, scene. The returned
+        view is rendered into its own SwiftUI `Settings` scene
+        alongside the main WindowGroup; if this is left at the
+        default (a bare `View()`), no Settings scene is emitted.
+
+        ```haxe
+        override function settings():View {
+            return new Form([
+                new Toggle("Dark Mode", "darkMode"),
+                new Picker("Default View", "defaultView", [...]),
+            ]);
+        }
+        ```
+
+        iOS / iPadOS / tvOS ignore the Settings scene at runtime —
+        on those platforms preferences belong in the system Settings
+        bundle or an in-app view. **/
+    public function settings():View {
+        return new View();
+    }
+
     /** Override to configure scenes (multi-window on macOS, visionOS). **/
     public function scenes():Array<Scene> {
         return [Scene.WindowGroup(appName, body)];

--- a/src/sui/App.hx
+++ b/src/sui/App.hx
@@ -28,7 +28,6 @@ class App {
         return new View();
     }
 
-<<<<<<< HEAD
     /** Override to attach top-level menus to the macOS menu bar. The
         returned array is read at compile time by the SwiftGenerator
         macro and emitted as a `.commands { CommandMenu(…) { … } … }`
@@ -41,7 +40,8 @@ class App {
     **/
     public function commands():Array<sui.ui.CommandMenu> {
         return [];
-=======
+    }
+
     /** Override to declare a Settings (Preferences) window — the
         standard macOS `App ▸ Preferences…` / ⌘, scene. The returned
         view is rendered into its own SwiftUI `Settings` scene
@@ -62,7 +62,6 @@ class App {
         bundle or an in-app view. **/
     public function settings():View {
         return new View();
->>>>>>> feat/settings-scene
     }
 
     /** Override to configure scenes (multi-window on macOS, visionOS). **/

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -53,13 +53,17 @@ class View {
         `calendarColors[i]` resolve to `appState.calendarColors[i]`
         (the per-iteration case for ForEach). Invalid hex falls back to
         `.primary` via the nil-coalescing operator on `Color(suiHex:)`. **/
-    public function foregroundHex(expr:String):View {
+    /** Accepts either a string literal (legacy stringly expr) or a
+        typed `State<String>` field reference — the macro extracts
+        the right Swift expression in both cases, no `.value`
+        ceremony at the call site. **/
+    public function foregroundHex(expr:Dynamic):View {
         modifierChain.push(ViewModifier.ForegroundHex(expr));
         return this;
     }
 
     /** Same as `foregroundHex` but for the background fill. **/
-    public function backgroundHex(expr:String):View {
+    public function backgroundHex(expr:Dynamic):View {
         modifierChain.push(ViewModifier.BackgroundHex(expr));
         return this;
     }

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -110,6 +110,16 @@ class View {
         return this;
     }
 
+    /** Trailing inspector pane (macOS) — slides out from the right
+        edge when `isPresentedBinding` becomes true. Maps to
+        SwiftUI's `.inspector(isPresented:_:)`. The standard macOS
+        pattern for showing details about the current selection
+        without opening a modal. **/
+    public function inspector(isPresentedBinding:Dynamic, content:View):View {
+        modifierChain.push(ViewModifier.Inspector(isPresentedBinding, content));
+        return this;
+    }
+
     public function alert(title:String, isPresentedBinding:Dynamic, ?message:String):View {
         modifierChain.push(ViewModifier.Alert(title, isPresentedBinding, message));
         return this;

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -50,6 +50,30 @@ class View {
         return this;
     }
 
+    /** Stretch the view horizontally to fill its parent. Compiles to
+        `.frame(maxWidth: .infinity)`. Useful for views that don't have
+        an intrinsic preferred width (e.g. Lists inside sheets). **/
+    public function fillWidth():View {
+        modifierChain.push(ViewModifier.FillWidth);
+        return this;
+    }
+
+    /** Stretch the view vertically to fill its parent. Compiles to
+        `.frame(maxHeight: .infinity)`. The canonical use case is
+        `List`-inside-`.sheet`: SwiftUI's `List` collapses to zero
+        height inside a sheet's content closure because its parent's
+        intrinsic height doesn't reserve room for a scrollable list. **/
+    public function fillHeight():View {
+        modifierChain.push(ViewModifier.FillHeight);
+        return this;
+    }
+
+    /** Shorthand for `.fillWidth().fillHeight()`. **/
+    public function fillBoth():View {
+        modifierChain.push(ViewModifier.FillBoth);
+        return this;
+    }
+
     public function background(color:ColorValue):View {
         modifierChain.push(ViewModifier.Background(color));
         return this;

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -55,6 +55,14 @@ class View {
         return this;
     }
 
+    /** Translucent SwiftUI `Material` as a background fill — picks
+        up content behind, adapts to dark/light mode automatically.
+        Standard in macOS sidebars, popovers, toolbars. **/
+    public function backgroundMaterial(style:MaterialStyle):View {
+        modifierChain.push(ViewModifier.BackgroundMaterial(style));
+        return this;
+    }
+
     public function cornerRadius(radius:Float):View {
         modifierChain.push(ViewModifier.CornerRadius(radius));
         return this;
@@ -382,4 +390,15 @@ enum TextFieldStyleValue {
     Automatic;
     RoundedBorder;
     Plain;
+}
+
+enum MaterialStyle {
+    /** The system default — `.regularMaterial`. Mid-thickness frosted glass. **/
+    Regular;
+    Thin;
+    UltraThin;
+    Thick;
+    UltraThick;
+    /** Bar-style material — used by `.bar`. Slightly tinted for toolbars. **/
+    Bar;
 }

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -246,6 +246,13 @@ class View {
         return this;
     }
 
+    /** Tooltip text shown on hover on macOS (and used as an
+        accessibility hint on iOS). Maps to SwiftUI's `.help(_:)`. **/
+    public function help(text:String):View {
+        modifierChain.push(ViewModifier.Help(text));
+        return this;
+    }
+
     /** Adjust brightness. Pass a Float or a State<Float>. **/
     public function brightness(amount:sui.state.StateOr<Float>):View {
         modifierChain.push(ViewModifier.Brightness(amount));

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -100,6 +100,15 @@ class View {
         return this;
     }
 
+    /** Apply a SwiftUI ButtonStyle. The most useful values for visual
+        hierarchy are `BorderedProminent` (the "filled" CTA look) and
+        `Bordered` (a thin outline). Use `Plain` to strip the default
+        chrome — handy inside Lists, sidebars and tappable cells. **/
+    public function buttonStyle(style:ButtonStyleValue):View {
+        modifierChain.push(ViewModifier.ButtonStyle(style));
+        return this;
+    }
+
     public function searchable(textBinding:String, ?prompt:String):View {
         modifierChain.push(ViewModifier.Searchable(textBinding, prompt));
         return this;
@@ -382,4 +391,13 @@ enum TextFieldStyleValue {
     Automatic;
     RoundedBorder;
     Plain;
+}
+
+enum ButtonStyleValue {
+    Automatic;
+    Plain;
+    Borderless;
+    Bordered;
+    BorderedProminent;
+    Link;
 }

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -45,6 +45,25 @@ class View {
         return this;
     }
 
+    /** Set the foreground colour from a hex string held in a state
+        variable. `expr` is emitted verbatim in the generated Swift body
+        and therefore picked up by the macro's state-prefix pass —
+        plain names like `calendarColor` resolve to
+        `appState.calendarColor`, and subscripted forms like
+        `calendarColors[i]` resolve to `appState.calendarColors[i]`
+        (the per-iteration case for ForEach). Invalid hex falls back to
+        `.primary` via the nil-coalescing operator on `Color(suiHex:)`. **/
+    public function foregroundHex(expr:String):View {
+        modifierChain.push(ViewModifier.ForegroundHex(expr));
+        return this;
+    }
+
+    /** Same as `foregroundHex` but for the background fill. **/
+    public function backgroundHex(expr:String):View {
+        modifierChain.push(ViewModifier.BackgroundHex(expr));
+        return this;
+    }
+
     public function frame(?width:Float, ?height:Float, ?alignment:Alignment):View {
         modifierChain.push(ViewModifier.Frame(width, height, alignment));
         return this;

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -290,6 +290,31 @@ class View {
         return this;
     }
 
+    /** Bind a keyboard shortcut to this view (typically a Button) —
+        maps to SwiftUI's `.keyboardShortcut(_:, modifiers:)`.
+
+        `key` accepts a single character (`"n"`, `"s"`, `","`) or one
+        of the named special keys: `"return"`, `"escape"`, `"delete"`,
+        `"tab"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`.
+
+        `modifiers` is any combination of `"command"`, `"option"`,
+        `"control"`, `"shift"`. Order doesn't matter; an empty array
+        means the bare key (rare; mostly used for `escape` and arrow
+        keys).
+
+        ```haxe
+        new Button("New Event", null, openNewEventAction)
+            .keyboardShortcut("n", ["command"]);
+
+        new Button("Today", null, showTodayAction)
+            .keyboardShortcut("t", ["command"]);
+        ```
+    **/
+    public function keyboardShortcut(key:String, ?modifiers:Array<String>):View {
+        modifierChain.push(ViewModifier.KeyboardShortcut(key, modifiers != null ? modifiers : []));
+        return this;
+    }
+
     /** Run a StateAction when the view appears. **/
     public function onAppearAction(action:sui.state.StateAction):View {
         modifierChain.push(ViewModifier.OnAppearAction(action));

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -164,6 +164,21 @@ class View {
         hierarchy are `BorderedProminent` (the "filled" CTA look) and
         `Bordered` (a thin outline). Use `Plain` to strip the default
         chrome — handy inside Lists, sidebars and tappable cells. **/
+    /** Apply a SwiftUI PickerStyle. Most useful: `Segmented` for the
+        native macOS switcher control. **/
+    public function pickerStyle(style:PickerStyleValue):View {
+        modifierChain.push(ViewModifier.PickerStyle(style));
+        return this;
+    }
+
+    /** Run a `StateAction` whenever the named state changes (e.g.
+        when a `Picker` writes its new selection). Maps to SwiftUI's
+        `.onChange(of:_:)`. **/
+    public function onChange(stateName:String, action:sui.state.StateAction):View {
+        modifierChain.push(ViewModifier.OnChange(stateName, action));
+        return this;
+    }
+
     public function buttonStyle(style:ButtonStyleValue):View {
         modifierChain.push(ViewModifier.ButtonStyle(style));
         return this;
@@ -460,4 +475,16 @@ enum ButtonStyleValue {
     Bordered;
     BorderedProminent;
     Link;
+}
+
+enum PickerStyleValue {
+    Automatic;
+    Inline;
+    Menu;
+    Palette;
+    /** macOS / iOS / iPadOS — the segmented "switcher" control,
+        typical for view-mode toolbars. **/
+    Segmented;
+    /** iOS only. **/
+    Wheel;
 }

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -128,7 +128,9 @@ class View {
         return this;
     }
 
-    public function opacity(value:Float):View {
+    /** Set the view's opacity (`0…1`). Accepts a literal `Float`
+        or a `State<Float>` for reactive fade in/out. **/
+    public function opacity(value:sui.state.StateOr<Float>):View {
         modifierChain.push(ViewModifier.Opacity(value));
         return this;
     }
@@ -317,6 +319,29 @@ class View {
     /** Offset the view position. Pass Floats or State<Float>s. **/
     public function offset(x:sui.state.StateOr<Float>, y:sui.state.StateOr<Float>):View {
         modifierChain.push(ViewModifier.Offset(x, y));
+        return this;
+    }
+
+    /** Offset by a *fraction* of the parent's measured size. Only
+        valid inside a `GeometryReader` — the codegen expression
+        references the `proxy` variable that container provides.
+        GeometryReader anchors its content at top-leading, so
+        `(0, 0)` leaves the view at the parent's top-leading edge,
+        `(0.5, 0.5)` lands it at the centre, and `(1, 1)` at
+        bottom-trailing. Accepts either a literal `Float` or a
+        `State<Float>` per axis. **/
+    public function proportionalOffset(xFraction:sui.state.StateOr<Float>, yFraction:sui.state.StateOr<Float>):View {
+        modifierChain.push(ViewModifier.ProportionalOffset(xFraction, yFraction));
+        return this;
+    }
+
+    /** Constrain the frame to a *fraction* of the parent's measured
+        size. Like `proportionalOffset`, only valid inside a
+        `GeometryReader`. Pass `null` (or any negative literal) on
+        an axis to leave that dimension intrinsic. Typical use is
+        timeline event blocks whose height = duration / day-length. **/
+    public function proportionalFrame(widthFraction:sui.state.StateOr<Float>, heightFraction:sui.state.StateOr<Float>):View {
+        modifierChain.push(ViewModifier.ProportionalFrame(widthFraction, heightFraction));
         return this;
     }
 

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -74,6 +74,19 @@ class View {
         return this;
     }
 
+    /** Pin this view to its **intrinsic** size on either axis. Compiles
+        to `.fixedSize(horizontal:, vertical:)`. Crucial for views like
+        `List` and `ScrollView` whose default size is "fill available" —
+        in some layout contexts (notably `.sheet` content on macOS,
+        where the container sizes to its children's intrinsic heights)
+        their default behaviour resolves to zero. Pinning to intrinsic
+        size makes them report the sum of their content heights
+        instead. **/
+    public function fixedSize(horizontal:Bool = false, vertical:Bool = true):View {
+        modifierChain.push(ViewModifier.FixedSize(horizontal, vertical));
+        return this;
+    }
+
     public function background(color:ColorValue):View {
         modifierChain.push(ViewModifier.Background(color));
         return this;

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -290,6 +290,16 @@ class View {
         return this;
     }
 
+    /** Run a `StateAction` when the given key is pressed while
+        this view (or a descendant) has focus. Maps to SwiftUI's
+        `.onKeyPress(_:action:)`. Use the same key-naming scheme
+        as `.keyboardShortcut` — single chars or named special
+        keys (`"return"`, `"escape"`, `"left"`, …). **/
+    public function onKeyPress(key:String, action:sui.state.StateAction):View {
+        modifierChain.push(ViewModifier.OnKeyPress(key, action));
+        return this;
+    }
+
     /** Run a StateAction when the view appears. **/
     public function onAppearAction(action:sui.state.StateAction):View {
         modifierChain.push(ViewModifier.OnAppearAction(action));

--- a/src/sui/View.hx
+++ b/src/sui/View.hx
@@ -212,6 +212,22 @@ class View {
         return this;
     }
 
+    /** Set the Inspector column's `min` / `ideal` / `max` widths.
+        SwiftUI defaults the Inspector column to a narrow ~250pt
+        track that can shrink further when the window resizes —
+        too tight for anything beyond simple key/value detail
+        lists. Apply this directly after `.inspector(...)`:
+        ```haxe
+        myView
+            .inspector("editorOpen", buildEditor())
+            .inspectorColumnWidth(360, 480, 720);
+        ```
+        Maps to `.inspectorColumnWidth(min:ideal:max:)`. **/
+    public function inspectorColumnWidth(min:Float, ideal:Float, max:Float):View {
+        modifierChain.push(ViewModifier.InspectorColumnWidth(min, ideal, max));
+        return this;
+    }
+
     public function alert(title:String, isPresentedBinding:Dynamic, ?message:String):View {
         modifierChain.push(ViewModifier.Alert(title, isPresentedBinding, message));
         return this;

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1819,7 +1819,7 @@ class SwiftGenerator {
     static function isModifier(name:String):Bool {
         return switch (name) {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
-                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" |
+                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" | "fixedSize" |
                  "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1876,6 +1876,13 @@ class SwiftGenerator {
                 'frame(maxHeight: .infinity)';
             case "fillBoth":
                 'frame(maxWidth: .infinity, maxHeight: .infinity)';
+            case "fixedSize":
+                // Defaults match Haxe-side: horizontal=false, vertical=true.
+                var h = if (args.length > 0) extractConstant(args[0]) else "false";
+                var v = if (args.length > 1) extractConstant(args[1]) else "true";
+                if (h == null) h = "false";
+                if (v == null) v = "true";
+                'fixedSize(horizontal: $h, vertical: $v)';
             case "disabled":
                 var v = if (args.length > 0) extractConstant(args[0]) else "true";
                 'disabled($v)';

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -218,6 +218,18 @@ class SwiftGenerator {
                 // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
+                // Replace "0..<name.count" — the ForEach iteration header
+                // emits the bare state name, which would otherwise resolve
+                // to an unbound identifier inside ContentView's body when
+                // the state lives on the separate AppState object that the
+                // bridge codepath generates.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
+                // Replace "(name[" (subscript access from inside string
+                // interpolation: "\(name[i])"). Matched with the leading
+                // paren so we don't accidentally rewrite suffix matches in
+                // longer identifiers, and so we leave existing
+                // "\(__APPSTATE__name[" alone (placeholder already in).
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1798,7 +1798,7 @@ class SwiftGenerator {
 
     static function isModifier(name:String):Bool {
         return switch (name) {
-            case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
+            case "padding" | "font" | "foregroundColor" | "background" | "backgroundMaterial" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1830,6 +1830,14 @@ class SwiftGenerator {
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'background(.${e != null ? camel(e) : "clear"})';
+            case "backgroundMaterial":
+                // MaterialStyle enum → SwiftUI Material constant.
+                // Regular → .regularMaterial, Bar → .bar, etc.
+                var e = if (args.length > 0) extractEnumName(args[0]) else null;
+                var swift = if (e == "Bar") ".bar"
+                    else if (e == null) ".regularMaterial"
+                    else '.${camel(e)}Material';
+                'background(${swift})';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,12 +150,19 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var commandsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "commands") {
+                // Walk `commands()` to find its returned TArrayDecl of
+                // `new CommandMenu(...)` values. Render each via
+                // `viewToSwift` and stitch them into a single
+                // `.commands { … }` block attached to WindowGroup.
+                var expr = field.expr();
+                if (expr != null) commandsSwift = walkCommandsFunc(expr);
             }
         }
 
@@ -174,6 +181,11 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (commandsSwift != "") {
+            appSwift.add("        .commands {\n");
+            appSwift.add(commandsSwift);
+            appSwift.add("        }\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -864,6 +876,72 @@ class SwiftGenerator {
         }
     }
 
+    /** Walk `commands(): Array<CommandMenu>` — find the returned
+        TArrayDecl, render each element via `viewToSwift`, and join
+        with the right indentation for the `.commands { … }` block
+        on the App's WindowGroup.
+
+        Haxe's typer hoists complex sub-expressions into TVar
+        bindings (e.g. inner `new Button(...)` references become
+        TLocal pointing at synthesised vars). `viewToSwift` resolves
+        TLocal through `localBindings`, so we walk the function body
+        ahead of time and collect every TVar's init expression
+        into that map. Without this pass the TLocal refs bubble up
+        as `// [sui] unhandled expression: TLocal` placeholders. **/
+    static function walkCommandsFunc(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "";
+        function collectBindings(e:haxe.macro.Type.TypedExpr):Void {
+            if (e == null) return;
+            switch (e.expr) {
+                case TVar(v, initExpr):
+                    if (initExpr != null) {
+                        localBindings.set(v.id, initExpr);
+                        collectBindings(initExpr);
+                    }
+                case TFunction(f): collectBindings(f.expr);
+                case TBlock(stmts):
+                    for (s in stmts) collectBindings(s);
+                case TReturn(re): collectBindings(re);
+                case TCast(inner, _): collectBindings(inner);
+                case TParenthesis(inner): collectBindings(inner);
+                case TMeta(_, inner): collectBindings(inner);
+                case TArrayDecl(elems):
+                    for (el in elems) collectBindings(el);
+                case TNew(_, _, args):
+                    for (a in args) collectBindings(a);
+                case TCall(_, args):
+                    for (a in args) collectBindings(a);
+                case TArray(arr, idx):
+                    collectBindings(arr);
+                    collectBindings(idx);
+                default:
+            }
+        }
+        collectBindings(expr);
+
+        // Descend through TFunction / TBlock / TReturn to the TArrayDecl.
+        function findArrayDecl(e:haxe.macro.Type.TypedExpr):Null<Array<haxe.macro.Type.TypedExpr>> {
+            if (e == null) return null;
+            switch (e.expr) {
+                case TFunction(f): return findArrayDecl(f.expr);
+                case TBlock(stmts):
+                    if (stmts.length > 0) return findArrayDecl(stmts[stmts.length - 1]);
+                case TReturn(re): return findArrayDecl(re);
+                case TCast(inner, _): return findArrayDecl(inner);
+                case TParenthesis(inner): return findArrayDecl(inner);
+                case TMeta(_, inner): return findArrayDecl(inner);
+                case TArrayDecl(elems): return elems;
+                default:
+            }
+            return null;
+        }
+        var elems = findArrayDecl(expr);
+        if (elems == null || elems.length == 0) return "";
+        var buf = new StringBuf();
+        for (cm in elems) buf.add(viewToSwift(cm, 3));
+        return buf.toString();
+    }
+
     static function viewToSwift(expr:haxe.macro.Type.TypedExpr, indent:Int):String {
         // Unwrap casts, metas, parentheses
         var unwrapped = unwrap(expr);
@@ -1357,6 +1435,27 @@ class SwiftGenerator {
                     buf.add('${pad}Section("${esc(header)}") {\n');
                 else
                     buf.add('${pad}Section {\n');
+                for (child in children)
+                    buf.add(viewToSwift(child, indent + 1));
+                buf.add('${pad}}\n');
+                return buf.toString();
+
+            case "CommandMenu":
+                // Top-level macOS menu-bar menu. Same shape as
+                // `Section` / `Menu`: label string + TArrayDecl of
+                // children. Attached to the App scene by the App.swift
+                // emitter via `.commands { … }`.
+                var label = if (args.length > 0) extractString(args[0]) else null;
+                var children:Array<haxe.macro.Type.TypedExpr> = [];
+                if (args.length > 1) {
+                    var uArg = unwrap(args[1]);
+                    switch (uArg.expr) {
+                        case TArrayDecl(el): children = el;
+                        default:
+                    }
+                }
+                var buf = new StringBuf();
+                buf.add('${pad}CommandMenu("${esc(label != null ? label : "")}") {\n');
                 for (child in children)
                     buf.add(viewToSwift(child, indent + 1));
                 buf.add('${pad}}\n');

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1810,7 +1810,7 @@ class SwiftGenerator {
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" |
-                 "onSubmit" | "onLongPressGesture" | "transition":
+                 "onSubmit" | "onLongPressGesture" | "transition" | "onKeyPress":
                 true;
             default: false;
         }
@@ -2049,6 +2049,16 @@ class SwiftGenerator {
                     'onLongPressGesture { ${actionCode} }';
                 else
                     'onLongPressGesture { }';
+            case "onKeyPress":
+                // args[0]: key name (String). args[1]: StateAction.
+                // Emits `.onKeyPress(<keyEquivalent>) { <action>; return .handled }`
+                // — `.handled` stops SwiftUI bubbling the event up the
+                // focus chain, the right default for an explicit handler.
+                var key = if (args.length > 0) extractString(args[0]) else "";
+                if (key == null) key = "";
+                var keyExpr = keyPressEquivalentToSwift(key);
+                var actionCode = if (args.length > 1) stateActionToSwift(args[1]) else "";
+                'onKeyPress(${keyExpr}) { ${actionCode}; return .handled }';
 
             default:
                 // Generic: try to pass through args
@@ -2235,6 +2245,31 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Map a sui key-name string to the matching SwiftUI
+        `KeyEquivalent` for `.onKeyPress`. Named keys resolve to
+        their static properties; anything else is wrapped in
+        `KeyEquivalent("<char>")`. Duplicates the logic
+        `feat/keyboard-shortcut` adds for `.keyboardShortcut`'s
+        `keyEquivalentToSwift` — to be deduped when both land. **/
+    static function keyPressEquivalentToSwift(key:String):String {
+        return switch (key.toLowerCase()) {
+            case "return": ".return";
+            case "escape": ".escape";
+            case "delete" | "backspace": ".delete";
+            case "tab": ".tab";
+            case "space": ".space";
+            case "left": ".leftArrow";
+            case "right": ".rightArrow";
+            case "up": ".upArrow";
+            case "down": ".downArrow";
+            case "home": ".home";
+            case "end": ".end";
+            case "pageup": ".pageUp";
+            case "pagedown": ".pageDown";
+            default: 'KeyEquivalent("${esc(key)}")';
+        };
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -397,6 +397,15 @@ class SwiftGenerator {
             s = StringTools.replace(s, "!" + n + "[", "!" + placeholder + n + "[");
             s = StringTools.replace(s, " " + n + "[", " " + placeholder + n + "[");
             s = StringTools.replace(s, "=" + n + "[", "=" + placeholder + n + "[");
+            // `name == X` / `name != X` — equality comparisons inside
+            // CustomSwift / foregroundHex / etc. (whitespace around the
+            // operator is required to avoid matching inside longer
+            // identifiers).
+            s = StringTools.replace(s, "(" + n + " ==", "(" + placeholder + n + " ==");
+            s = StringTools.replace(s, "(" + n + " !=", "(" + placeholder + n + " !=");
+            s = StringTools.replace(s, " " + n + " ==", " " + placeholder + n + " ==");
+            s = StringTools.replace(s, " " + n + " !=", " " + placeholder + n + " !=");
+            s = StringTools.replace(s, ":" + n + " ==", ":" + placeholder + n + " ==");
         }
         return StringTools.replace(s, placeholder, "appState.");
     }
@@ -1224,6 +1233,7 @@ class SwiftGenerator {
         switch (name) {
             case "VStack" | "HStack" | "ZStack" | "LazyVStack" | "LazyHStack":
                 var spacing:String = null;
+                var alignment:String = null;
                 var children:Array<haxe.macro.Type.TypedExpr> = [];
                 for (arg in args) {
                     var uArg = unwrap(arg);
@@ -1235,12 +1245,23 @@ class SwiftGenerator {
                                 case TInt(v): spacing = Std.string(v);
                                 default:
                             }
+                        // Alignment is passed as an enum value
+                        // (`Alignment.TopLeading`, `HorizontalAlignment.Leading`,
+                        // `VerticalAlignment.Top`, …). The macro-side
+                        // emission was previously dropping it on the
+                        // floor; pick it up and forward to the SwiftUI
+                        // initializer.
                         default:
+                            var e = extractEnumName(uArg);
+                            if (e != null) alignment = camel(e);
                     }
                 }
                 var buf = new StringBuf();
-                if (spacing != null)
-                    buf.add('${pad}${name}(spacing: ${spacing}) {\n');
+                var initParts:Array<String> = [];
+                if (alignment != null) initParts.push('alignment: .${alignment}');
+                if (spacing != null) initParts.push('spacing: ${spacing}');
+                if (initParts.length > 0)
+                    buf.add('${pad}${name}(${initParts.join(", ")}) {\n');
                 else
                     buf.add('${pad}${name} {\n');
                 for (child in children)
@@ -1317,6 +1338,22 @@ class SwiftGenerator {
             case "Circle": return '${pad}Circle()\n';
             case "Capsule": return '${pad}Capsule()\n';
             case "Ellipse": return '${pad}Ellipse()\n';
+
+            case "GeometryReader":
+                // The single child is rendered inside SwiftUI's
+                // GeometryReader closure. The proxy is bound to a
+                // fixed name (`proxy`) that the `.proportionalOffset`
+                // modifier emits expressions against.
+                var buf = new StringBuf();
+                buf.add('${pad}GeometryReader { proxy in\n');
+                for (arg in args) {
+                    switch (arg.expr) {
+                        case TConst(TNull):
+                        default: buf.add(viewToSwift(arg, indent + 1));
+                    }
+                }
+                buf.add('${pad}}\n');
+                return buf.toString();
 
             case "LinearGradient":
                 // args[0] = TArrayDecl<ColorValue>, args[1] = startPoint String,
@@ -2299,11 +2336,30 @@ class SwiftGenerator {
                                         var fnName = if (args.length > 2) extractString(args[2]) else "unknown";
                                         var argStr = if (args.length > 3) extractBridgeArgs(args[3]) else "";
                                         '${p0} = "${esc(loadingVal)}"; Task.detached { let r = HaxeBridgeC.${fnName}(${argStr}); await MainActor.run { ${p0} = r } }';
+                                    case "BridgeCallVoid":
+                                        // No state to write — the return value is
+                                        // intentionally dropped. Used by periodic ticks
+                                        // and other fire-and-forget bridge calls.
+                                        var fnName = if (args.length > 0) extractString(args[0]) else "unknown";
+                                        var argStr = if (args.length > 1) extractBridgeArgs(args[1]) else "";
+                                        'Task.detached { _ = HaxeBridgeC.${fnName}(${argStr}) }';
                                     case "Animated":
                                         var innerAction = if (args.length > 0) stateActionToSwift(args[0]) else null;
                                         var curve = if (args.length > 1) resolveAnimationCurve(args[1]) else "default";
                                         if (innerAction != null)
                                             'withAnimation(.${curve}) { ${innerAction} }';
+                                        else
+                                            null;
+                                    case "IntervalLoop":
+                                        // `seconds * 1_000_000_000` keeps the call site
+                                        // expressed in seconds (`60`, `0.5`) instead of
+                                        // raw nanoseconds — Task.sleep takes nanos so we
+                                        // convert at codegen time.
+                                        var secs = if (args.length > 0) extractConstant(args[0]) else "60";
+                                        if (secs == null) secs = "60";
+                                        var innerAction = if (args.length > 1) stateActionToSwift(args[1]) else null;
+                                        if (innerAction != null)
+                                            'while !Task.isCancelled { try? await Task.sleep(nanoseconds: UInt64((${secs}) * 1_000_000_000)); ${innerAction} }';
                                         else
                                             null;
                                     default: null;
@@ -2333,7 +2389,7 @@ class SwiftGenerator {
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
                  "onAppearAction" | "taskAction" | "toolbarItem" |
-                 "blur" | "scaleEffect" | "rotationEffect" | "offset" |
+                 "blur" | "scaleEffect" | "rotationEffect" | "offset" | "proportionalOffset" | "proportionalFrame" |
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" | "help" |
@@ -2377,7 +2433,10 @@ class SwiftGenerator {
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":
-                var v = if (args.length > 0) extractConstant(args[0]) else "1.0";
+                // Accept Float literal or State<Float> via the
+                // shared resolveModifierValue helper (same path as
+                // `.scaleEffect`, `.offset`, …).
+                var v = resolveModifierValue(args, 0, "1.0");
                 'opacity(${v})';
             case "navigationTitle":
                 var s = if (args.length > 0) extractString(args[0]) else "";
@@ -2389,6 +2448,10 @@ class SwiftGenerator {
                 var parts:Array<String> = [];
                 if (args.length > 0) { var w = extractConstant(args[0]); if (w != null) parts.push('width: $w'); }
                 if (args.length > 1) { var h = extractConstant(args[1]); if (h != null) parts.push('height: $h'); }
+                if (args.length > 2) {
+                    var a = extractEnumName(args[2]);
+                    if (a != null) parts.push('alignment: .${camel(a)}');
+                }
                 'frame(${parts.join(", ")})';
             // Stretch helpers — workarounds for SwiftUI containers that
             // collapse to zero in layout contexts without a definite
@@ -2575,6 +2638,33 @@ class SwiftGenerator {
                 var x = resolveModifierValue(args, 0, "0");
                 var y = resolveModifierValue(args, 1, "0");
                 'offset(x: $x, y: $y)';
+            case "proportionalOffset":
+                // Reads `proxy.size.{width,height}` — must live
+                // inside a `GeometryReader`. GeometryReader anchors
+                // its content at `.topLeading`, so a fraction of
+                // 0 = top/leading edge, 0.5 = centre, 1 = bottom/
+                // trailing edge (offset directly maps fraction →
+                // pixels-from-top-leading, no centre correction).
+                var xf = resolveModifierValue(args, 0, "0");
+                var yf = resolveModifierValue(args, 1, "0");
+                'offset(x: proxy.size.width * (${xf}), y: proxy.size.height * (${yf}))';
+            case "proportionalFrame":
+                // Same constraint as `proportionalOffset` — must
+                // live inside a `GeometryReader`. Pass a literal
+                // negative constant on an axis (e.g. `-1.0`) to
+                // drop that argument and leave the dimension at
+                // its intrinsic value.
+                function isNegativeLiteral(s:String):Bool {
+                    return s != null && s.charAt(0) == "-"
+                        && Std.parseFloat(s) != null && Std.parseFloat(s) < 0;
+                }
+                var wf = resolveModifierValue(args, 0, "-1");
+                var hf = resolveModifierValue(args, 1, "-1");
+                var parts:Array<String> = [];
+                if (!isNegativeLiteral(wf)) parts.push('width: proxy.size.width * (${wf})');
+                if (!isNegativeLiteral(hf)) parts.push('height: proxy.size.height * (${hf})');
+                if (parts.length == 0) "frame()";
+                else 'frame(${parts.join(", ")}, alignment: .topLeading)';
 
             // --- Image effects ---
             case "brightness":
@@ -2763,20 +2853,32 @@ class SwiftGenerator {
                     case TInt(v): return Std.string(v);
                     case TFloat(v): return v;
                     case TBool(b): return b ? "true" : "false";
-                    case TString(s): return s; // backward compat: string as state name
+                    case TString(s):
+                        // Legacy: stringly-typed state name. Wrap in
+                        // the AppState placeholder so the body pass
+                        // picks it up reliably regardless of where it
+                        // sits syntactically — `y: foo)`, `blur(foo)`,
+                        // etc., wouldn't match the pattern-based pass
+                        // otherwise.
+                        return "__APPSTATE__" + s;
                     default:
                 }
             case TField(_, fa):
-                // State<T> field reference — extract field name
+                // Typed State<T> field reference — same reasoning:
+                // emit the placeholder so the final `__APPSTATE__` →
+                // `appState.` substitution catches the identifier in
+                // every Swift syntactic context, including
+                // `offset(x: 0, y: NAME)` where the pattern pass
+                // doesn't try to match.
                 switch (fa) {
-                    case FInstance(_, _, fieldRef): return fieldRef.get().name;
-                    case FStatic(_, fieldRef): return fieldRef.get().name;
+                    case FInstance(_, _, fieldRef): return "__APPSTATE__" + fieldRef.get().name;
+                    case FStatic(_, fieldRef): return "__APPSTATE__" + fieldRef.get().name;
                     default:
                 }
             default:
-                // Check for TLocal referencing a field (common with @:state)
+                // TLocal referencing a `@:state` field — same path.
                 var fieldName = extractThisField(e);
-                if (fieldName != null) return fieldName;
+                if (fieldName != null) return "__APPSTATE__" + fieldName;
         }
         return defaultVal;
     }

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1203,6 +1203,17 @@ class SwiftGenerator {
                 var url = if (args.length > 1) extractString(args[1]) else "";
                 return '${pad}Link("${esc(label != null ? label : "")}", destination: URL(string: "${esc(url != null ? url : "")}")!)\n';
 
+            case "ShareLink":
+                // args[0]: item (String). args[1]: optional label
+                // String — without it, SwiftUI shows the default
+                // share-arrow icon.
+                var item = if (args.length > 0) extractString(args[0]) else "";
+                var label = if (args.length > 1) extractString(args[1]) else null;
+                if (label != null && label != "")
+                    return '${pad}ShareLink(item: "${esc(item != null ? item : "")}") {\n${pad}    Text("${esc(label)}")\n${pad}}\n';
+                else
+                    return '${pad}ShareLink(item: "${esc(item != null ? item : "")}")\n';
+
             case "Image":
                 if (args.length > 0) {
                     var n = extractString(args[0]);

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -2120,7 +2120,8 @@ class SwiftGenerator {
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" |
-                 "onSubmit" | "onLongPressGesture" | "transition":
+                 "onSubmit" | "onLongPressGesture" | "transition" |
+                 "onChange":
                 true;
             default: false;
         }
@@ -2226,6 +2227,15 @@ class SwiftGenerator {
                     'onTapGesture { ${actionCode} }';
                 else
                     'onTapGesture { }';
+            case "onChange":
+                // args[0] = state name (String literal), args[1] = StateAction.
+                // Emits `.onChange(of: appState.<name>) { _, _ in <action> }`
+                // — the body-wide appState-prefix pass doesn't reach
+                // through `of:`, so we insert the prefix here.
+                var stateName = if (args.length > 0) extractString(args[0]) else null;
+                if (stateName == null) stateName = "";
+                var actionCode = if (args.length > 1) stateActionToSwift(args[1]) else null;
+                'onChange(of: appState.${stateName}) { _, _ in ${actionCode != null ? actionCode : ""} }';
             case "onAppearAction":
                 var actionCode = if (args.length > 0) stateActionToSwift(args[0]) else null;
                 if (actionCode != null)

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -230,6 +230,14 @@ class SwiftGenerator {
                 // longer identifiers, and so we leave existing
                 // "\(__APPSTATE__name[" alone (placeholder already in).
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
+                // Replace "!name[" (logical-not subscript) and " name["
+                // (statement-leading bare reference inside CustomSwift
+                // bodies). Two narrow lookbehinds rather than a generic
+                // `name[` to avoid false-positives where the state name
+                // appears as a suffix of another identifier.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "!" + n + "[", "!" + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, " " + n + "[", " " + placeholder + n + "[");
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "=" + n + "[", "=" + placeholder + n + "[");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -218,6 +218,11 @@ class SwiftGenerator {
                 // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
                 bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
+                // Replace "ForEach(name," — the closure form of ForEach
+                // iterates directly over a state array; without this,
+                // the bare array name would be unbound inside the body
+                // when state lives on the appState bridge object.
+                bodyWithAppState = StringTools.replace(bodyWithAppState, "ForEach(" + n + ",", "ForEach(" + placeholder + n + ",");
             }
             // Now resolve all placeholders to "appState."
             bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -202,13 +202,26 @@ class SwiftGenerator {
         }
         appSwift.add("        HaxeRuntime.initialize()\n");
         appSwift.add("    }\n\n");
-        appSwift.add("    var body: some Scene {\n");
+        // The `commands` block lives at Scene level, not inside a
+        // View — so `appState.X` references inside StateActions can't
+        // resolve through ContentView's `@Bindable var appState`.
+        // Inject the same declaration into the App struct so the
+        // commands closures see it.
+        var needsAppStateInApp = (commandsSwift != "" || hasSettings)
+            && needsRuntimeBridge && stateDecls.length > 0;
+        if (needsAppStateInApp) {
+            appSwift.add("\n    @Bindable var appState = AppState.shared\n");
+        }
+        appSwift.add("\n    var body: some Scene {\n");
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
         if (commandsSwift != "") {
+            var emitted = needsAppStateInApp
+                ? rewriteStateRefsToAppState(commandsSwift, stateDecls)
+                : commandsSwift;
             appSwift.add("        .commands {\n");
-            appSwift.add(commandsSwift);
+            appSwift.add(emitted);
             appSwift.add("        }\n");
         }
         if (hasSettings) {
@@ -245,52 +258,7 @@ class SwiftGenerator {
         viewSwift.add("    var body: some View {\n");
 
         if (needsRuntimeBridge && stateDecls.length > 0) {
-            // Replace state variable references with appState.name
-            var bodyWithAppState = bodySwift;
-            // Use placeholders to avoid cascading replacements
-            var placeholder = "__APPSTATE__";
-            for (sd in stateDecls) {
-                var n = sd.name;
-                // Replace $name (Swift binding) with $__APPSTATE__name
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "$" + n, "$" + placeholder + n);
-                // Replace \(name) (Swift string interpolation) with \(__APPSTATE__name)
-                bodyWithAppState = StringTools.replace(bodyWithAppState, '\\(' + n + ')', '\\(' + placeholder + n + ')');
-                // Replace {name} in bridge call args with __APPSTATE__interpolation
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "{" + n + "}", '\\(' + placeholder + n + ')');
-                // Replace bare "name = " (assignment in closures) with __APPSTATE__name =
-                bodyWithAppState = StringTools.replace(bodyWithAppState, n + " = ", placeholder + n + " = ");
-                // Replace "if name" (ConditionalView boolean) with "if __APPSTATE__name"
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + " ", "if " + placeholder + n + " ");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "if " + n + "\n", "if " + placeholder + n + "\n");
-                // Replace "0..<name.count" — the ForEach iteration header
-                // emits the bare state name, which would otherwise resolve
-                // to an unbound identifier inside ContentView's body when
-                // the state lives on the separate AppState object that the
-                // bridge codepath generates.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
-                // Replace "ForEach(name," — the closure form of ForEach
-                // iterates directly over a state array; without this,
-                // the bare array name would be unbound inside the body
-                // when state lives on the appState bridge object.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "ForEach(" + n + ",", "ForEach(" + placeholder + n + ",");
-                // Replace "(name[" (subscript access from inside string
-                // interpolation: "\(name[i])"). Matched with the leading
-                // paren so we don't accidentally rewrite suffix matches in
-                // longer identifiers, and so we leave existing
-                // "\(__APPSTATE__name[" alone (placeholder already in).
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "(" + n + "[", "(" + placeholder + n + "[");
-                // Replace "!name[" (logical-not subscript) and " name["
-                // (statement-leading bare reference inside CustomSwift
-                // bodies). Two narrow lookbehinds rather than a generic
-                // `name[` to avoid false-positives where the state name
-                // appears as a suffix of another identifier.
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "!" + n + "[", "!" + placeholder + n + "[");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, " " + n + "[", " " + placeholder + n + "[");
-                bodyWithAppState = StringTools.replace(bodyWithAppState, "=" + n + "[", "=" + placeholder + n + "[");
-            }
-            // Now resolve all placeholders to "appState."
-            bodyWithAppState = StringTools.replace(bodyWithAppState, placeholder, "appState.");
-            viewSwift.add(bodyWithAppState);
+            viewSwift.add(rewriteStateRefsToAppState(bodySwift, stateDecls));
         } else {
             viewSwift.add(bodySwift);
         }
@@ -313,20 +281,7 @@ class SwiftGenerator {
             }
             viewSwift.add("    var body: some View {\n");
             if (needsRuntimeBridge && stateDecls.length > 0) {
-                // Reuse the same appState-prefix pass as ContentView.
-                var s = settingsSwift;
-                var placeholder = "__APPSTATE__";
-                for (sd in stateDecls) {
-                    var n = sd.name;
-                    s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
-                    s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
-                    s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
-                    s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
-                    s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
-                    s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
-                }
-                s = StringTools.replace(s, placeholder, "appState.");
-                viewSwift.add(s);
+                viewSwift.add(rewriteStateRefsToAppState(settingsSwift, stateDecls));
             } else {
                 viewSwift.add(settingsSwift);
             }
@@ -402,6 +357,48 @@ class SwiftGenerator {
                 }
             }
         }
+    }
+
+    /** Rewrite the bare state names produced by `viewToSwift` /
+        StateAction emission so they target the bridged `appState.X`
+        object. The codepath that emits Swift assumes everything will
+        be hoisted under a `@Bindable var appState = AppState.shared`
+        — but the emitter doesn't know that yet, so we patch the
+        identifiers in a single textual pass. Run this on every
+        chunk that lives in a struct holding `appState`: the
+        ContentView body, the SettingsView body, and (for
+        scene-level constructs like `.commands { … }`) the App
+        struct's body. **/
+    static function rewriteStateRefsToAppState(s:String, stateDecls:Array<{name:String, swiftType:String, defaultValue:String}>):String {
+        var placeholder = "__APPSTATE__";
+        for (sd in stateDecls) {
+            var n = sd.name;
+            // `$name` (Swift binding)
+            s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
+            // `\(name)` (Swift string interpolation)
+            s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
+            // `{name}` (bridge call argument templates)
+            s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
+            // `name = ` (assignment inside closures)
+            s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
+            // `if name ` / `if name\n` (ConditionalView boolean)
+            s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
+            s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
+            // `0..<name.count` (ForEach iteration header)
+            s = StringTools.replace(s, "0..<" + n + ".count", "0..<" + placeholder + n + ".count");
+            // `ForEach(name,` (closure-form ForEach over a state array)
+            s = StringTools.replace(s, "ForEach(" + n + ",", "ForEach(" + placeholder + n + ",");
+            // `(name[` `!name[` ` name[` `=name[` (subscript-access
+            // shapes that show up inside CustomSwift / interpolation
+            // bodies). Each lookbehind is narrow enough to avoid
+            // matching a state name that happens to be a suffix of a
+            // longer identifier.
+            s = StringTools.replace(s, "(" + n + "[", "(" + placeholder + n + "[");
+            s = StringTools.replace(s, "!" + n + "[", "!" + placeholder + n + "[");
+            s = StringTools.replace(s, " " + n + "[", " " + placeholder + n + "[");
+            s = StringTools.replace(s, "=" + n + "[", "=" + placeholder + n + "[");
+        }
+        return StringTools.replace(s, placeholder, "appState.");
     }
 
     /** Generate an @Observable AppState class for bridged state management. **/

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -471,7 +471,9 @@ class SwiftGenerator {
             buf.add('#include "sui/ui/Button.h"\n');
         }
         buf.add('#include "sui/state/State.h"\n');
-        buf.add("#include <string.h>\n\n");
+        buf.add("#include <string.h>\n");
+        buf.add("#include <mutex>\n");
+        buf.add("#include <cstdio>\n\n");
         buf.add("// Auto-generated bridge: calls into hxcpp-compiled Haxe code.\n\n");
 
         buf.add("extern \"C\" void __hxcpp_lib_main() {}\n");
@@ -481,6 +483,43 @@ class SwiftGenerator {
             buf.add("extern \"C\" void haxe_bridge_register_state_fn(void (*)(const char*, const char*));\n");
         }
         buf.add("\n");
+
+        // ── Bridge safety scaffold ────────────────────────────────
+        //
+        // Every entry into this file ends up running hxcpp-compiled
+        // Haxe code, which:
+        //   1) requires the calling thread's stack to be registered as
+        //      a GC root via hx::SetTopOfStack, and
+        //   2) is *not* internally synchronized — two threads running
+        //      Haxe at once is undefined behaviour.
+        //
+        // SwiftUI clients hit case 2 the moment they mix
+        //   - computed properties that query state on every body re-eval
+        //     (the closure form of ForEach lands here), and
+        //   - `Task.detached { HaxeBridgeC.foo(...) }` for any user
+        //     `@:expose`d function.
+        //
+        // We serialize both with a single global recursive_mutex.
+        // Recursive is necessary because Haxe→Swift callbacks
+        // (`_bridge_state_forwarder`) can in turn invoke other bridge
+        // entrypoints, all on the same thread.
+        //
+        // Each entrypoint also wraps the call in try/catch — an
+        // uncaught Haxe `throw` walks past `__cxa_throw` and aborts
+        // the process; without the catch we have no way to surface
+        // the error to Swift.
+        buf.add("static std::recursive_mutex _haxe_runtime_mutex;\n\n");
+
+        buf.add("struct HaxeBridgeScope {\n");
+        buf.add("    std::lock_guard<std::recursive_mutex> _lock;\n");
+        buf.add("    int _gc_dummy;\n");
+        buf.add("    HaxeBridgeScope() : _lock(_haxe_runtime_mutex), _gc_dummy(0) {\n");
+        buf.add("        hx::SetTopOfStack(&_gc_dummy, true);\n");
+        buf.add("    }\n");
+        buf.add("    ~HaxeBridgeScope() {\n");
+        buf.add("        hx::SetTopOfStack((int*)0, true);\n");
+        buf.add("    }\n");
+        buf.add("};\n\n");
 
         if (hasRuntimeActions) {
             // State callback: Swift → C → Haxe State.set() → C → Swift AppState
@@ -495,125 +534,113 @@ class SwiftGenerator {
             buf.add("}\n\n");
         }
 
-        // haxe_bridge_init: boots hxcpp runtime, registers callbacks, builds view tree
+        // haxe_bridge_init: boots hxcpp runtime, registers callbacks, builds view tree.
+        // Boot itself isn't reentrant, so we hold the lock for the whole init body.
         buf.add("void haxe_bridge_init(void) {\n");
+        buf.add("    std::lock_guard<std::recursive_mutex> _lock(_haxe_runtime_mutex);\n");
         buf.add("    int dummy = 0;\n");
         buf.add("    hx::SetTopOfStack(&dummy, true);\n");
-        buf.add("    hx::Boot();\n");
-        buf.add("    __boot_all();\n");
-
+        buf.add("    try {\n");
+        buf.add("        hx::Boot();\n");
+        buf.add("        __boot_all();\n");
         if (hasRuntimeActions) {
-            buf.add("\n    // Register state change forwarder (State.set() → Swift AppState)\n");
-            buf.add("    haxe_bridge_register_state_fn(_bridge_state_forwarder);\n");
-            buf.add("\n    // Build view tree to register button actions\n");
-            buf.add('    auto app = ::${appClassName}_obj::__new();\n');
-            buf.add("    app->body();\n");
+            buf.add("        // Register state change forwarder (State.set() → Swift AppState)\n");
+            buf.add("        haxe_bridge_register_state_fn(_bridge_state_forwarder);\n");
+            buf.add("        // Build view tree to register button actions\n");
+            buf.add('        auto app = ::${appClassName}_obj::__new();\n');
+            buf.add("        app->body();\n");
         }
-
+        buf.add("    } catch (::Dynamic _e) {\n");
+        buf.add('        fprintf(stderr, "[sui] haxe_bridge_init: Haxe exception during boot\\n");\n');
+        buf.add("    } catch (...) {\n");
+        buf.add('        fprintf(stderr, "[sui] haxe_bridge_init: C++ exception during boot\\n");\n');
+        buf.add("    }\n");
         buf.add("}\n\n");
 
         if (hasRuntimeActions) {
             // invoke_action: calls into Haxe Button action registry
             buf.add("void haxe_bridge_invoke_action(int32_t actionId) {\n");
-            buf.add("    // Set up hxcpp thread-local storage for this thread\n");
-            buf.add("    // (needed when called from Swift Task.detached background threads)\n");
-            buf.add("    int dummy = 0;\n");
-            buf.add("    hx::SetTopOfStack(&dummy, true);\n");
-            buf.add("    ::sui::ui::Button_obj::_invokeAction(actionId);\n");
-            buf.add("    hx::SetTopOfStack((int*)0, true);\n");
+            buf.add("    HaxeBridgeScope _scope;\n");
+            buf.add("    try {\n");
+            buf.add("        ::sui::ui::Button_obj::_invokeAction(actionId);\n");
+            buf.add("    } catch (::Dynamic _e) {\n");
+            buf.add('        fprintf(stderr, "[sui] haxe_bridge_invoke_action: Haxe exception\\n");\n');
+            buf.add("    } catch (...) {\n");
+            buf.add('        fprintf(stderr, "[sui] haxe_bridge_invoke_action: C++ exception\\n");\n');
+            buf.add("    }\n");
             buf.add("}\n\n");
         }
 
-        // Shared-memory query functions — typed accessors avoid serialization
-        // Helper macro pattern: GC setup, call, GC teardown
-        buf.add("// Array length\n");
-        buf.add("int32_t haxe_bridge_array_length(const char* stateName) {\n");
-        buf.add("    if (!stateName) return -1;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getArrayLength(::String(stateName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        // ── Shared-memory query functions ─────────────────────────
+        emitSharedMemoryReader(buf, "haxe_bridge_array_length",
+            "int32_t", "0",
+            "if (!stateName) return -1;\n",
+            "(int32_t)::sui::state::State_obj::_getArrayLength(::String(stateName))",
+            "stateName.c_str", null,
+            "int32_t");
 
-        // String element
-        buf.add("const char* haxe_bridge_array_string_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return \"\";\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    ::String r = ::sui::state::State_obj::_getArrayStringElement(::String(stateName), (int)index);\n");
-        buf.add("    static thread_local char _buf[4096];\n");
-        buf.add("    strncpy(_buf, r.__CStr(), sizeof(_buf) - 1); _buf[sizeof(_buf) - 1] = 0;\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return _buf;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_string_element",
+            "const char*", "\"\"",
+            "if (!stateName) return \"\";\n",
+            "::sui::state::State_obj::_getArrayStringElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", "haxe_string_to_buf",
+            "::String");
 
-        // Int element — no string conversion
-        buf.add("int32_t haxe_bridge_array_int_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return 0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getArrayIntElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_int_element",
+            "int32_t", "0",
+            "if (!stateName) return 0;\n",
+            "(int32_t)::sui::state::State_obj::_getArrayIntElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "int32_t");
 
-        // Float element — no string conversion
-        buf.add("double haxe_bridge_array_float_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return 0.0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    double r = (double)::sui::state::State_obj::_getArrayFloatElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_float_element",
+            "double", "0.0",
+            "if (!stateName) return 0.0;\n",
+            "(double)::sui::state::State_obj::_getArrayFloatElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "double");
 
-        // Bool element — no string conversion
-        buf.add("bool haxe_bridge_array_bool_element(const char* stateName, int32_t index) {\n");
-        buf.add("    if (!stateName) return false;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    bool r = (bool)::sui::state::State_obj::_getArrayBoolElement(::String(stateName), (int)index);\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_array_bool_element",
+            "bool", "false",
+            "if (!stateName) return false;\n",
+            "(bool)::sui::state::State_obj::_getArrayBoolElement(::String(stateName), (int)index)",
+            "stateName.c_str + index", null,
+            "bool");
 
-        // Object field accessors
-        buf.add("const char* haxe_bridge_object_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return \"\";\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    ::String r = ::sui::state::State_obj::_getObjectField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    static thread_local char _buf[4096];\n");
-        buf.add("    strncpy(_buf, r.__CStr(), sizeof(_buf) - 1); _buf[sizeof(_buf) - 1] = 0;\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return _buf;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_field",
+            "const char*", "\"\"",
+            "if (!stateName || !fieldName) return \"\";\n",
+            "::sui::state::State_obj::_getObjectField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", "haxe_string_to_buf",
+            "::String");
 
-        buf.add("int32_t haxe_bridge_object_int_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return 0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    int32_t r = (int32_t)::sui::state::State_obj::_getObjectIntField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_int_field",
+            "int32_t", "0",
+            "if (!stateName || !fieldName) return 0;\n",
+            "(int32_t)::sui::state::State_obj::_getObjectIntField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "int32_t");
 
-        buf.add("double haxe_bridge_object_float_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return 0.0;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    double r = (double)::sui::state::State_obj::_getObjectFloatField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_float_field",
+            "double", "0.0",
+            "if (!stateName || !fieldName) return 0.0;\n",
+            "(double)::sui::state::State_obj::_getObjectFloatField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "double");
 
-        buf.add("bool haxe_bridge_object_bool_field(const char* stateName, int32_t index, const char* fieldName) {\n");
-        buf.add("    if (!stateName || !fieldName) return false;\n");
-        buf.add("    int _gc = 0; hx::SetTopOfStack(&_gc, true);\n");
-        buf.add("    bool r = (bool)::sui::state::State_obj::_getObjectBoolField(::String(stateName), (int)index, ::String(fieldName));\n");
-        buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-        buf.add("    return r;\n");
-        buf.add("}\n\n");
+        emitSharedMemoryReader(buf, "haxe_bridge_object_bool_field",
+            "bool", "false",
+            "if (!stateName || !fieldName) return false;\n",
+            "(bool)::sui::state::State_obj::_getObjectBoolField(::String(stateName), (int)index, ::String(fieldName))",
+            "stateName.c_str + index + fieldName.c_str", null,
+            "bool");
 
+        // ── User-defined @:expose functions ───────────────────────
         for (fn in fns) {
             var cParams = [for (p in fn.params) '${swiftTypeToCType(p.swiftType)} ${p.name}'];
             if (cParams.length == 0) cParams.push("void");
-            buf.add('${swiftTypeToCType(fn.returnType)} haxe_bridge_${fn.name}(${cParams.join(", ")}) {\n');
-            buf.add("    int _gc_dummy = 0;\n");
-            buf.add("    hx::SetTopOfStack(&_gc_dummy, true);\n");
+            var cReturnType = swiftTypeToCType(fn.returnType);
+            buf.add('$cReturnType haxe_bridge_${fn.name}(${cParams.join(", ")}) {\n');
 
             // Build hxcpp call arguments
             var hxArgs:Array<String> = [];
@@ -628,36 +655,112 @@ class SwiftGenerator {
             }
 
             var call = '::${appClassName}_obj::${fn.name}(${hxArgs.join(", ")})';
+            var fnName = fn.name;
 
             switch (fn.returnType) {
                 case "String":
-                    buf.add('    ::String _hx_result = $call;\n');
-                    buf.add("    static thread_local char _buf[4096];\n");
-                    buf.add("    const char* _cstr = _hx_result.__CStr();\n");
-                    buf.add("    strncpy(_buf, _cstr, sizeof(_buf) - 1);\n");
-                    buf.add("    _buf[sizeof(_buf) - 1] = 0;\n");
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _buf;\n");
+                    buf.add('    static thread_local char _buf[4096];\n');
+                    buf.add('    _buf[0] = 0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try {\n');
+                    buf.add('            ::String _hx_result = $call;\n');
+                    buf.add('            const char* _cstr = _hx_result.__CStr();\n');
+                    buf.add('            strncpy(_buf, _cstr, sizeof(_buf) - 1);\n');
+                    buf.add('            _buf[sizeof(_buf) - 1] = 0;\n');
+                    buf.add('        } catch (::Dynamic _e) {\n');
+                    buf.add('            fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n");\n');
+                    buf.add('        } catch (...) {\n');
+                    buf.add('            fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n");\n');
+                    buf.add('        }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _buf;\n');
                 case "Int":
-                    buf.add('    int32_t _ret = (int32_t)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    int32_t _ret = 0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (int32_t)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 case "Double" | "Float":
-                    buf.add('    double _ret = (double)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    double _ret = 0.0;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (double)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 case "Bool":
-                    buf.add('    bool _ret = (bool)$call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
-                    buf.add("    return _ret;\n");
+                    buf.add('    bool _ret = false;\n');
+                    buf.add('    {\n');
+                    buf.add('        HaxeBridgeScope _scope;\n');
+                    buf.add('        try { _ret = (bool)$call; }\n');
+                    buf.add('        catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('        catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
+                    buf.add('    }\n');
+                    buf.add('    return _ret;\n');
                 default:
-                    buf.add('    $call;\n');
-                    buf.add("    hx::SetTopOfStack((int*)0, true);\n");
+                    buf.add('    HaxeBridgeScope _scope;\n');
+                    buf.add('    try { $call; }\n');
+                    buf.add('    catch (::Dynamic _e) { fprintf(stderr, "[sui] haxe_bridge_$fnName: Haxe exception\\n"); }\n');
+                    buf.add('    catch (...) { fprintf(stderr, "[sui] haxe_bridge_$fnName: C++ exception\\n"); }\n');
             }
 
             buf.add("}\n\n");
         }
         return buf.toString();
+    }
+
+    /** Helper for the shared-memory state readers. They all share the
+        same shape: a guard, a HaxeBridgeScope, a try/catch around the
+        Haxe call, and either a numeric return or a thread-local
+        buffer for String returns. The macro-level abstraction keeps
+        the bridge body small and consistent. **/
+    static function emitSharedMemoryReader(buf:StringBuf, fnName:String,
+            cReturnType:String, defaultReturn:String, guard:String,
+            call:String, _:String, stringMode:Null<String>, hxResultType:String):Void {
+        var isString = (stringMode == "haxe_string_to_buf");
+        // Reconstruct the C parameter list from the function name —
+        // the naming convention is enough to discriminate.
+        var params = if (fnName.indexOf("object") >= 0)
+            "const char* stateName, int32_t index, const char* fieldName";
+        else if (fnName.indexOf("element") >= 0)
+            "const char* stateName, int32_t index";
+        else
+            "const char* stateName";
+        buf.add('$cReturnType ${fnName}($params) {\n');
+        buf.add('    $guard');
+        if (isString) {
+            buf.add('    static thread_local char _buf[4096];\n');
+            buf.add('    _buf[0] = 0;\n');
+        } else {
+            buf.add('    $cReturnType _ret = $defaultReturn;\n');
+        }
+        buf.add('    {\n');
+        buf.add('        HaxeBridgeScope _scope;\n');
+        buf.add('        try {\n');
+        if (isString) {
+            buf.add('            ::String r = $call;\n');
+            buf.add('            strncpy(_buf, r.__CStr(), sizeof(_buf) - 1);\n');
+            buf.add('            _buf[sizeof(_buf) - 1] = 0;\n');
+        } else {
+            buf.add('            _ret = $call;\n');
+        }
+        buf.add('        } catch (::Dynamic _e) {\n');
+        buf.add('            fprintf(stderr, "[sui] ${fnName}: Haxe exception\\n");\n');
+        buf.add('        } catch (...) {\n');
+        buf.add('            fprintf(stderr, "[sui] ${fnName}: C++ exception\\n");\n');
+        buf.add('        }\n');
+        buf.add('    }\n');
+        if (isString) {
+            buf.add('    return _buf;\n');
+        } else {
+            buf.add('    return _ret;\n');
+        }
+        buf.add('}\n\n');
     }
 
     static function generateBridgeSwift(appClassName:String, fns:Array<{name:String, params:Array<{name:String, swiftType:String}>, returnType:String}>, hasRuntimeActions:Bool):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1826,10 +1826,10 @@ class SwiftGenerator {
                 'font(.${e != null ? camel(e) : "body"})';
             case "foregroundColor":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'foregroundStyle(.${e != null ? camel(e) : "primary"})';
+                'foregroundStyle(${colorEnumToSwift(e, "primary")})';
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'background(.${e != null ? camel(e) : "clear"})';
+                'background(${colorEnumToSwift(e, "clear")})';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":
@@ -1854,7 +1854,7 @@ class SwiftGenerator {
                 'lineLimit($v)';
             case "shadow":
                 var parts:Array<String> = [];
-                if (args.length > 0) { var e = extractEnumName(args[0]); if (e != null) parts.push('color: .${camel(e)}'); }
+                if (args.length > 0) { var e = extractEnumName(args[0]); if (e != null) parts.push('color: ${colorEnumToSwift(e, "primary")}'); }
                 if (args.length > 1) { var r = extractConstant(args[1]); if (r != null) parts.push('radius: $r'); }
                 'shadow(${parts.join(", ")})';
             case "textFieldStyle":
@@ -1955,7 +1955,7 @@ class SwiftGenerator {
                 'overlay {\n${contentSwift}${pad}}';
             case "tint":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
-                'tint(.${e != null ? camel(e) : "accentColor"})';
+                'tint(${colorEnumToSwift(e, "accentColor")})';
             case "badge":
                 var v = if (args.length > 0) extractConstant(args[0]) else null;
                 if (v != null)
@@ -2235,6 +2235,23 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Translate a `ColorValue` enum-name into the Swift expression to
+        pass to a colour-consuming modifier (`foregroundStyle`,
+        `background`, `shadow`, `tint`, etc.). Most values map to the
+        dotted shorthand (`.red`, `.blue`, `.primary`, …) because
+        SwiftUI exposes them on every relevant `ShapeStyle`/`Color`
+        type. `Accent` is the exception: there is no `.accent`
+        `ShapeStyle` member, so we emit the explicit static
+        `Color.accentColor` instead, which is universally available
+        and works as both a `Color` and a `ShapeStyle`. **/
+    static function colorEnumToSwift(name:Null<String>, fallback:String):String {
+        if (name == null) return '.${fallback}';
+        return switch (name) {
+            case "Accent": "Color.accentColor";
+            default: '.${camel(name)}';
+        };
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1580,6 +1580,16 @@ class SwiftGenerator {
     /** Try to inline a view-returning function call. Returns null if not resolvable. **/
     static function tryInlineViewCall(field:haxe.macro.Type.ClassField, args:Array<haxe.macro.Type.TypedExpr>, indent:Int):String {
         if (!returnsView(field)) return null;
+        // Static factories that carry @:swiftName have their own Swift
+        // emission (`generateSwiftCall` reads :swiftLabel-tagged params
+        // and builds the matching initializer call) — inlining them
+        // would walk the Haxe body and ignore those annotations,
+        // emitting whatever stub the factory uses internally. The
+        // canonical case is `Image.systemImage(...)` whose body builds
+        // `new Image("")` as a placeholder, so without this guard the
+        // generated Swift came out as `Image("")` instead of
+        // `Image(systemName: "...")`.
+        if (getMetaString(field.meta, ":swiftName") != null) return null;
         var funcExpr = field.expr();
         if (funcExpr == null) return null;
 

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1696,7 +1696,32 @@ class SwiftGenerator {
         if (expr == null) return expr;
         return switch (expr.expr) {
             case TBlock(stmts):
-                if (stmts.length == 1) unwrapLambdaBody(stmts[0]) else expr;
+                // Single-stmt blocks are the common shape (the typer
+                // wraps `arg -> expr` into `function(arg){ return expr; }`),
+                // but the typer also synthesizes intermediate locals
+                // for sub-expressions when the body references types
+                // it can't inline — e.g. `arr.value[i]` for a Haxe
+                // property — landing here as multi-statement blocks
+                // of TVar declarations followed by a final TReturn.
+                // Register the TVars in `localBindings` so the rest
+                // of the view-tree pass can dereference them, then
+                // unwrap the final TReturn.
+                if (stmts.length == 0) expr;
+                else if (stmts.length == 1) unwrapLambdaBody(stmts[0]);
+                else {
+                    for (s in stmts) {
+                        switch (s.expr) {
+                            case TVar(v, initExpr) if (initExpr != null):
+                                localBindings.set(v.id, initExpr);
+                            default:
+                        }
+                    }
+                    var last = stmts[stmts.length - 1];
+                    switch (last.expr) {
+                        case TReturn(_): unwrapLambdaBody(last);
+                        default: expr;
+                    }
+                }
             case TReturn(e):
                 e != null ? unwrapLambdaBody(e) : expr;
             case TMeta(_, e): unwrapLambdaBody(e);
@@ -2473,8 +2498,28 @@ class SwiftGenerator {
         appState-prefix pass rewrites bare names in. **/
     static function resolveHexExpr(args:Array<haxe.macro.Type.TypedExpr>):String {
         if (args.length == 0) return "\"\"";
+        // 1. Closure-form lambda item ref ("item", "other.value[i]")
         var itemExpr = extractItemExpr(args[0]);
         if (itemExpr != null) return itemExpr;
+        // 2. Direct State<String> field reference (`.foregroundHex(myColorState)`).
+        //    Emit `appState.<name>` straight away — the
+        //    body-wide appState-prefix pass keys on bracket /
+        //    interpolation / assignment patterns and doesn't match
+        //    bare names inside `Color(suiHex: …)`, so we have to
+        //    insert the prefix here ourselves.
+        var e = unwrap(args[0]);
+        switch (e.expr) {
+            case TField(_, fa):
+                switch (fa) {
+                    case FInstance(_, _, fieldRef): return 'appState.${fieldRef.get().name}';
+                    case FStatic(_, fieldRef): return 'appState.${fieldRef.get().name}';
+                    default:
+                }
+            default:
+                var fieldName = extractThisField(e);
+                if (fieldName != null) return 'appState.${fieldName}';
+        }
+        // 3. Legacy: string literal embedded verbatim.
         var s = extractString(args[0]);
         return s != null ? s : "\"\"";
     }

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1809,7 +1809,7 @@ class SwiftGenerator {
                  "blur" | "scaleEffect" | "rotationEffect" | "offset" |
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
-                 "listStyle" | "aspectRatio" | "accessibilityLabel" |
+                 "listStyle" | "aspectRatio" | "accessibilityLabel" | "help" |
                  "onSubmit" | "onLongPressGesture" | "transition":
                 true;
             default: false;
@@ -2038,6 +2038,9 @@ class SwiftGenerator {
             case "accessibilityLabel":
                 var s = if (args.length > 0) extractString(args[0]) else "";
                 'accessibilityLabel("${esc(s != null ? s : "")}")';
+            case "help":
+                var s = if (args.length > 0) extractString(args[0]) else "";
+                'help("${esc(s != null ? s : "")}")';
 
             // --- Interaction ---
             case "onSubmit":

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -979,6 +979,11 @@ class SwiftGenerator {
 
             case "Text":
                 if (args.length > 0) {
+                    // Lambda item reference inside ForEach(state, item -> …):
+                    // render as a string-interpolated Text so the live
+                    // array element shows up.
+                    var itemExpr = extractItemExpr(args[0]);
+                    if (itemExpr != null) return '${pad}Text("\\(${itemExpr})")\n';
                     var text = extractString(args[0]);
                     if (text != null) return '${pad}Text("${esc(text)}")\n';
                     // Check for property reference: this.fieldName → emit as expression
@@ -1482,19 +1487,100 @@ class SwiftGenerator {
     **/
     static function forEachToSwift(args:Array<haxe.macro.Type.TypedExpr>, indent:Int):String {
         var pad = ind(indent);
-        // args[0] = array state name (String) or State<Array> field ref, args[1] = item var name (String), args[2] = child view
+        // Two call shapes:
+        //   * legacy 3-arg: (arrayName, itemVarName, childView) — keep working
+        //   * lambda 2-arg: (arrayName, item -> childView) — closure form
+        //     where `item` references inside the body resolve to the
+        //     per-iteration element via `currentItemBinding`. Modifiers
+        //     and Text codegen check the binding before falling back to
+        //     constant-string extraction.
         var arrayName = if (args.length > 0) resolveStateName(args[0]) else "items";
-        var itemName = if (args.length > 1) extractString(args[1]) else "item";
 
+        var lambda = (args.length >= 2) ? unwrapLambda(args[1]) : null;
+        if (lambda != null) {
+            var itemName = lambda.paramName != null && lambda.paramName != "" ? lambda.paramName : "item";
+            var prev = currentItemBinding;
+            // Closure form: iterate directly over the array's elements
+            // so the Haxe-typed lambda parameter and the Swift binding
+            // refer to the same value (`color: String`, not the index).
+            // SwiftUI's `ForEach(_:id:_:)` requires the element type to
+            // be Hashable — `id: \.self` is the standard escape hatch.
+            currentItemBinding = {
+                paramId: lambda.paramId,
+                swiftExpr: itemName,
+            };
+            var buf = new StringBuf();
+            buf.add('${pad}ForEach(${arrayName}, id: \\.self) { ${itemName} in\n');
+            buf.add(viewToSwift(lambda.body, indent + 1));
+            buf.add('${pad}}\n');
+            currentItemBinding = prev;
+            return buf.toString();
+        }
+
+        // Legacy form
+        var itemName = if (args.length > 1) extractString(args[1]) else "item";
         var buf = new StringBuf();
         buf.add('${pad}ForEach(0..<${arrayName}.count, id: \\.self) { ${itemName} in\n');
-
         if (args.length > 2) {
             buf.add(viewToSwift(args[2], indent + 1));
         }
-
         buf.add('${pad}}\n');
         return buf.toString();
+    }
+
+    /** State tracking for the closure form of ForEach: when the macro
+        is mid-traversal of a lambda body, this points to the iteration
+        parameter and the matching Swift expression. **/
+    static var currentItemBinding:Null<{paramId:Int, swiftExpr:String}> = null;
+
+    /** Unwrap (cast/paren/etc.) and check if the expression is a
+        unary-arg lambda — used by the closure form of ForEach. The
+        lambda body is also unwrapped: arrow-syntax bodies arrive as a
+        TBlock wrapping a single TReturn, which would otherwise fall
+        through `viewToSwift` and emit "unhandled expression: TBlock". **/
+    static function unwrapLambda(expr:haxe.macro.Type.TypedExpr):Null<{paramId:Int, paramName:String, body:haxe.macro.Type.TypedExpr}> {
+        if (expr == null) return null;
+        var e = unwrap(expr);
+        return switch (e.expr) {
+            case TFunction(fn):
+                if (fn.args.length != 1) null;
+                else {
+                    paramId: fn.args[0].v.id,
+                    paramName: fn.args[0].v.name,
+                    body: unwrapLambdaBody(fn.expr),
+                };
+            default: null;
+        }
+    }
+
+    /** Peel TBlock/TReturn/TMeta layers Haxe adds around the actual
+        expression returned by an arrow-syntax lambda. **/
+    static function unwrapLambdaBody(expr:haxe.macro.Type.TypedExpr):haxe.macro.Type.TypedExpr {
+        if (expr == null) return expr;
+        return switch (expr.expr) {
+            case TBlock(stmts):
+                if (stmts.length == 1) unwrapLambdaBody(stmts[0]) else expr;
+            case TReturn(e):
+                e != null ? unwrapLambdaBody(e) : expr;
+            case TMeta(_, e): unwrapLambdaBody(e);
+            case TParenthesis(e): unwrapLambdaBody(e);
+            case TCast(e, _): unwrapLambdaBody(e);
+            default: expr;
+        }
+    }
+
+    /** Return the Swift expression for the currently-bound lambda item
+        if the given typed expression is a reference to it. Used by
+        modifier codegens that want to accept either a literal string
+        or a typed item reference. **/
+    static function extractItemExpr(expr:haxe.macro.Type.TypedExpr):Null<String> {
+        if (currentItemBinding == null || expr == null) return null;
+        var e = unwrap(expr);
+        return switch (e.expr) {
+            case TLocal(v):
+                v.id == currentItemBinding.paramId ? currentItemBinding.swiftExpr : null;
+            default: null;
+        }
     }
 
     /**
@@ -1965,8 +2051,16 @@ class SwiftGenerator {
                     s != null ? 'badge(${s})' : "badge(0)";
                 }
             case "tag":
-                var s = if (args.length > 0) extractString(args[0]) else null;
-                s != null ? 'tag("${esc(s)}")' : 'tag("")';
+                // A typed lambda item ref inside a closure-form ForEach
+                // is emitted as a raw Swift expression (no quotes) so
+                // `.tag(item)` binds to the iterated value. Constant
+                // string args remain literal-quoted as before.
+                var rawExpr = if (args.length > 0) extractItemExpr(args[0]) else null;
+                if (rawExpr != null) 'tag(${rawExpr})';
+                else {
+                    var s = if (args.length > 0) extractString(args[0]) else null;
+                    s != null ? 'tag("${esc(s)}")' : 'tag("")';
+                }
 
             // --- Visual effects (accept constants or state variable names) ---
             case "blur":

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1037,6 +1037,11 @@ class SwiftGenerator {
                 }
                 return buf.toString();
 
+            case "Rectangle": return '${pad}Rectangle()\n';
+            case "Circle": return '${pad}Circle()\n';
+            case "Capsule": return '${pad}Capsule()\n';
+            case "Ellipse": return '${pad}Ellipse()\n';
+
             case "Spacer":
                 if (args.length > 0) {
                     var v = extractConstant(args[0]);

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1801,7 +1801,7 @@ class SwiftGenerator {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
-                 "toggleStyle" | "pickerStyle" | "scrollIndicators" |
+                 "buttonStyle" | "toggleStyle" | "pickerStyle" | "scrollIndicators" |
                  "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
@@ -1860,6 +1860,9 @@ class SwiftGenerator {
             case "textFieldStyle":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'textFieldStyle(.${e != null ? camel(e) : "automatic"})';
+            case "buttonStyle":
+                var e = if (args.length > 0) extractEnumName(args[0]) else null;
+                'buttonStyle(.${e != null ? camel(e) : "automatic"})';
             case "toggleStyle":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'toggleStyle(.${e != null ? camel(e) : "automatic"})';

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1798,7 +1798,8 @@ class SwiftGenerator {
 
     static function isModifier(name:String):Bool {
         return switch (name) {
-            case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
+            case "padding" | "font" | "foregroundColor" | "background" |
+                 "foregroundHex" | "backgroundHex" | "bold" | "italic" |
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
@@ -1830,6 +1831,18 @@ class SwiftGenerator {
             case "background":
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'background(.${e != null ? camel(e) : "clear"})';
+            case "foregroundHex":
+                // The expression is embedded verbatim and run through the
+                // body's appState-prefix pass — so bare names like
+                // `calendarColor` or subscripted names like
+                // `calendarColors[i]` resolve correctly at the call site.
+                var expr = if (args.length > 0) extractString(args[0]) else null;
+                if (expr == null) expr = "\"\"";
+                'foregroundStyle(Color(suiHex: ${expr}) ?? Color.primary)';
+            case "backgroundHex":
+                var expr = if (args.length > 0) extractString(args[0]) else null;
+                if (expr == null) expr = "\"\"";
+                'background(Color(suiHex: ${expr}) ?? Color.clear)';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -165,10 +165,19 @@ class SwiftGenerator {
         appSwift.add("@main\n");
         appSwift.add('struct ${className}App: App {\n');
         appSwift.add("    init() {\n");
-        appSwift.add("        HaxeRuntime.initialize()\n");
         if (needsRuntimeBridge) {
+            // Register the swift-side state callback BEFORE the
+            // runtime boots. `HaxeRuntime.initialize()` calls
+            // `haxe_bridge_init`, which itself constructs the
+            // application class — any `State.setByName` (or
+            // `State<T>(initialValue, ...)` push) issued during the
+            // constructor only reaches AppState if the swift
+            // callback is already wired up. With the previous order
+            // those updates were dropped silently and AppState
+            // stayed on its literal defaults until the next mutation.
             appSwift.add("        HaxeBridgeC.registerCallbacks()\n");
         }
+        appSwift.add("        HaxeRuntime.initialize()\n");
         appSwift.add("    }\n\n");
         appSwift.add("    var body: some Scene {\n");
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1810,7 +1810,8 @@ class SwiftGenerator {
                  "brightness" | "contrast" | "saturation" | "grayscale" |
                  "fullScreenCover" | "popover" | "contextMenu" | "swipeActions" | "refreshable" |
                  "listStyle" | "aspectRatio" | "accessibilityLabel" |
-                 "onSubmit" | "onLongPressGesture" | "transition":
+                 "onSubmit" | "onLongPressGesture" | "transition" |
+                 "keyboardShortcut":
                 true;
             default: false;
         }
@@ -2049,6 +2050,35 @@ class SwiftGenerator {
                     'onLongPressGesture { ${actionCode} }';
                 else
                     'onLongPressGesture { }';
+            case "keyboardShortcut":
+                // args[0]: key string. args[1]: modifiers Array<String>.
+                // Emits `.keyboardShortcut(KeyEquivalent("k"), modifiers: [.command, ...])`
+                // — the named-key sentinels resolve to `.return`, `.escape`,
+                // `.delete`, `.tab`, `.space`, `.leftArrow`, `.rightArrow`,
+                // `.upArrow`, `.downArrow`; everything else maps directly to
+                // `KeyEquivalent("<char>")`.
+                var key = if (args.length > 0) extractString(args[0]) else null;
+                if (key == null) key = "";
+                var keyExpr = keyEquivalentToSwift(key);
+                var mods:Array<String> = [];
+                if (args.length > 1) {
+                    var arrE = unwrap(args[1]);
+                    switch (arrE.expr) {
+                        case TArrayDecl(elems):
+                            for (el in elems) {
+                                var s = extractString(el);
+                                if (s != null) {
+                                    var swift = modifierKeyToSwift(s);
+                                    if (swift != null) mods.push(swift);
+                                }
+                            }
+                        default:
+                    }
+                }
+                if (mods.length > 0)
+                    'keyboardShortcut(${keyExpr}, modifiers: [${mods.join(", ")}])';
+                else
+                    'keyboardShortcut(${keyExpr})';
 
             default:
                 // Generic: try to pass through args
@@ -2235,6 +2265,41 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Map a sui `keyboardShortcut` key string to the matching
+        SwiftUI `KeyEquivalent`. Named keys (return, escape, …)
+        resolve to their static properties; anything else is wrapped
+        in `KeyEquivalent("<char>")`. **/
+    static function keyEquivalentToSwift(key:String):String {
+        return switch (key.toLowerCase()) {
+            case "return": ".return";
+            case "escape": ".escape";
+            case "delete" | "backspace": ".delete";
+            case "tab": ".tab";
+            case "space": ".space";
+            case "left": ".leftArrow";
+            case "right": ".rightArrow";
+            case "up": ".upArrow";
+            case "down": ".downArrow";
+            case "home": ".home";
+            case "end": ".end";
+            case "pageup": ".pageUp";
+            case "pagedown": ".pageDown";
+            default: 'KeyEquivalent("${esc(key)}")';
+        };
+    }
+
+    /** Map a sui modifier-key name to its `EventModifiers` member. **/
+    static function modifierKeyToSwift(name:String):Null<String> {
+        return switch (name.toLowerCase()) {
+            case "command" | "cmd": ".command";
+            case "option" | "alt": ".option";
+            case "control" | "ctrl": ".control";
+            case "shift": ".shift";
+            case "capslock": ".capsLock";
+            default: null;
+        };
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1362,6 +1362,26 @@ class SwiftGenerator {
                 buf.add('${pad}}\n');
                 return buf.toString();
 
+            case "Menu":
+                // First arg is the label (String), second is a
+                // TArrayDecl of child views (typically Buttons or
+                // nested Menus).
+                var label = if (args.length > 0) extractString(args[0]) else null;
+                var children:Array<haxe.macro.Type.TypedExpr> = [];
+                if (args.length > 1) {
+                    var uArg = unwrap(args[1]);
+                    switch (uArg.expr) {
+                        case TArrayDecl(el): children = el;
+                        default:
+                    }
+                }
+                var buf = new StringBuf();
+                buf.add('${pad}Menu("${esc(label != null ? label : "")}") {\n');
+                for (child in children)
+                    buf.add(viewToSwift(child, indent + 1));
+                buf.add('${pad}}\n');
+                return buf.toString();
+
             case "AdaptiveStack":
                 needsHorizontalSizeClass = true;
                 var buf = new StringBuf();

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1574,18 +1574,68 @@ class SwiftGenerator {
         }
     }
 
-    /** Return the Swift expression for the currently-bound lambda item
-        if the given typed expression is a reference to it. Used by
-        modifier codegens that want to accept either a literal string
-        or a typed item reference. **/
+    /** Return the Swift expression for the currently-bound lambda
+        item if the given typed expression is a reference to it.
+        Used by modifier codegens that want to accept either a literal
+        string or a typed item reference.
+
+        Recognises two shapes:
+          1. **Bare lambda param** (`item`) — the closure parameter
+             itself. Resolves to `currentItemBinding.swiftExpr`.
+          2. **Indexed parallel-array access** (`other.value[item]`,
+             where `other` is a `State<Array<T>>` field and `item` is
+             the closure param). Resolves to
+             `appState.<other-state-name>[<swiftExpr>]`, so a
+             closure-form ForEach iterating one array can subscript
+             any number of parallel arrays by typed Haxe code instead
+             of stringly `"otherArrayName[i]"` patterns. **/
     static function extractItemExpr(expr:haxe.macro.Type.TypedExpr):Null<String> {
         if (currentItemBinding == null || expr == null) return null;
         var e = unwrap(expr);
-        return switch (e.expr) {
+        switch (e.expr) {
             case TLocal(v):
-                v.id == currentItemBinding.paramId ? currentItemBinding.swiftExpr : null;
-            default: null;
+                return v.id == currentItemBinding.paramId
+                    ? currentItemBinding.swiftExpr
+                    : null;
+            case TArray(arr, idx):
+                // Check whether the index is the bound lambda param.
+                var idxU = unwrap(idx);
+                var idxRef = switch (idxU.expr) {
+                    case TLocal(v) if (v.id == currentItemBinding.paramId):
+                        currentItemBinding.swiftExpr;
+                    default: null;
+                };
+                if (idxRef == null) return null;
+                // Resolve the array's underlying state-field name.
+                // `state.value` shows up as either a direct TField
+                // (Haxe property) or as a TCall to its getter.
+                var stateName = resolveValueAccessStateName(arr);
+                if (stateName == null) return null;
+                return '${stateName}[${idxRef}]';
+            default:
+                return null;
         }
+    }
+
+    /** Walk `someState.value` (or its getter form) and recover the
+        receiver's state-field name. Returns null for anything that
+        doesn't look like a `.value` access on a State<T> field. **/
+    static function resolveValueAccessStateName(expr:haxe.macro.Type.TypedExpr):Null<String> {
+        if (expr == null) return null;
+        var e = unwrap(expr);
+        switch (e.expr) {
+            case TField(receiver, _):
+                return resolveStateName(receiver);
+            case TCall(callee, _):
+                var calU = unwrap(callee);
+                switch (calU.expr) {
+                    case TField(receiver, _):
+                        return resolveStateName(receiver);
+                    default:
+                }
+            default:
+        }
+        return null;
     }
 
     /**
@@ -1923,17 +1973,13 @@ class SwiftGenerator {
                 var e = if (args.length > 0) extractEnumName(args[0]) else null;
                 'background(.${e != null ? camel(e) : "clear"})';
             case "foregroundHex":
-                // The expression is embedded verbatim and run through the
-                // body's appState-prefix pass — so bare names like
-                // `calendarColor` or subscripted names like
-                // `calendarColors[i]` resolve correctly at the call site.
-                var expr = if (args.length > 0) extractString(args[0]) else null;
-                if (expr == null) expr = "\"\"";
-                'foregroundStyle(Color(suiHex: ${expr}) ?? Color.primary)';
+                // Closure-form ForEach typed item refs and indexed
+                // accesses (`item`, `other.value[i]`) take priority;
+                // legacy string-name args fall through to the verbatim
+                // embed + appState-prefix pass.
+                'foregroundStyle(Color(suiHex: ${resolveHexExpr(args)}) ?? Color.primary)';
             case "backgroundHex":
-                var expr = if (args.length > 0) extractString(args[0]) else null;
-                if (expr == null) expr = "\"\"";
-                'background(Color(suiHex: ${expr}) ?? Color.clear)';
+                'background(Color(suiHex: ${resolveHexExpr(args)}) ?? Color.clear)';
             case "bold": "bold()";
             case "italic": "italic()";
             case "opacity":
@@ -2229,6 +2275,10 @@ class SwiftGenerator {
     /** Resolve a modifier argument: number (literal) or string (state variable name, emitted bare). **/
     static function resolveModifierValue(args:Array<haxe.macro.Type.TypedExpr>, index:Int, defaultVal:String):String {
         if (index >= args.length) return defaultVal;
+        // Closure-form ForEach item refs (`item`, `other.value[i]`)
+        // take priority over the legacy string/field paths.
+        var itemExpr = extractItemExpr(args[index]);
+        if (itemExpr != null) return itemExpr;
         var e = unwrap(args[index]);
         switch (e.expr) {
             case TConst(c):
@@ -2252,6 +2302,19 @@ class SwiftGenerator {
                 if (fieldName != null) return fieldName;
         }
         return defaultVal;
+    }
+
+    /** Resolve the hex/colour expression for `foregroundHex` /
+        `backgroundHex`. Tries the typed closure-form item ref first
+        (so the body can pass a lambda param or `other.value[i]`),
+        then falls back to the legacy string literal which the
+        appState-prefix pass rewrites bare names in. **/
+    static function resolveHexExpr(args:Array<haxe.macro.Type.TypedExpr>):String {
+        if (args.length == 0) return "\"\"";
+        var itemExpr = extractItemExpr(args[0]);
+        if (itemExpr != null) return itemExpr;
+        var s = extractString(args[0]);
+        return s != null ? s : "\"\"";
     }
 
     static function extractBridgeArgs(expr:haxe.macro.Type.TypedExpr):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -150,14 +150,29 @@ class SwiftGenerator {
 
         // 4. Walk body() method (may also set needsRuntimeBridge for complex closures)
         var bodySwift = "        // empty body\n";
+        var settingsSwift = "";
         for (field in cls.fields.get()) {
             if (field.name == "body") {
                 var expr = field.expr();
                 if (expr != null)
                     bodySwift = walkFunc(expr, 2);
-                break;
+            } else if (field.name == "settings") {
+                var expr = field.expr();
+                if (expr != null) settingsSwift = walkFunc(expr, 2);
             }
         }
+        // The default `settings()` returns `new View()`, which
+        // `viewToSwift` renders as a "Unknown view" placeholder
+        // comment. Treat that as "user didn't override" and skip
+        // emitting the Settings scene altogether.
+        var hasSettings = settingsSwift != "" && settingsSwift.indexOf("Unknown view") == -1;
+        // The Settings scene only makes sense if its preferences
+        // share state with the rest of the app — `Toggle("Dark Mode",
+        // "darkMode")` in Settings must read/write the same value
+        // ContentView observes. Force the bridged AppState path so
+        // both view structs reference `AppState.shared` rather than
+        // each carrying its own private `@State` copies.
+        if (hasSettings) needsRuntimeBridge = true;
 
         // 5. Emit App.swift (after needsRuntimeBridge is finalized)
         var appSwift = new StringBuf();
@@ -174,6 +189,13 @@ class SwiftGenerator {
         appSwift.add('        WindowGroup("${esc(appName)}") {\n');
         appSwift.add("            ContentView()\n");
         appSwift.add("        }\n");
+        if (hasSettings) {
+            appSwift.add("        #if os(macOS)\n");
+            appSwift.add("        Settings {\n");
+            appSwift.add("            SettingsView()\n");
+            appSwift.add("        }\n");
+            appSwift.add("        #endif\n");
+        }
         appSwift.add("    }\n");
         appSwift.add("}\n");
 
@@ -228,6 +250,42 @@ class SwiftGenerator {
 
         viewSwift.add("    }\n");
         viewSwift.add("}\n");
+
+        // 5b. Optionally emit a SettingsView struct alongside ContentView.
+        //     Same `@Bindable var appState` (or `@State`s) wiring so it
+        //     can read/write the same app-wide state.
+        if (hasSettings) {
+            viewSwift.add("\n");
+            viewSwift.add("struct SettingsView: View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                viewSwift.add("    @Bindable var appState = AppState.shared\n\n");
+            } else {
+                for (sd in stateDecls)
+                    viewSwift.add('    @State private var ${sd.name}: ${sd.swiftType} = ${sd.defaultValue}\n');
+                if (stateDecls.length > 0) viewSwift.add("\n");
+            }
+            viewSwift.add("    var body: some View {\n");
+            if (needsRuntimeBridge && stateDecls.length > 0) {
+                // Reuse the same appState-prefix pass as ContentView.
+                var s = settingsSwift;
+                var placeholder = "__APPSTATE__";
+                for (sd in stateDecls) {
+                    var n = sd.name;
+                    s = StringTools.replace(s, "$" + n, "$" + placeholder + n);
+                    s = StringTools.replace(s, '\\(' + n + ')', '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, "{" + n + "}", '\\(' + placeholder + n + ')');
+                    s = StringTools.replace(s, n + " = ", placeholder + n + " = ");
+                    s = StringTools.replace(s, "if " + n + " ", "if " + placeholder + n + " ");
+                    s = StringTools.replace(s, "if " + n + "\n", "if " + placeholder + n + "\n");
+                }
+                s = StringTools.replace(s, placeholder, "appState.");
+                viewSwift.add(s);
+            } else {
+                viewSwift.add(settingsSwift);
+            }
+            viewSwift.add("    }\n");
+            viewSwift.add("}\n");
+        }
 
         // 6. Generate model structs for Observable subclasses used by this app
         var modelSwift = new StringBuf();

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1802,7 +1802,7 @@ class SwiftGenerator {
                  "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
-                 "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
+                 "sheet" | "inspector" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
                  "onAppearAction" | "taskAction" | "toolbarItem" |
@@ -1908,6 +1908,11 @@ class SwiftGenerator {
                 var pad = ind(indent + 1);
                 var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Sheet")\n';
                 'sheet(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
+            case "inspector":
+                var binding = if (args.length > 0) resolveStateName(args[0]) else "isPresented";
+                var pad = ind(indent + 1);
+                var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Inspector")\n';
+                'inspector(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
             case "alert":
                 var title = if (args.length > 0) extractString(args[0]) else "Alert";
                 var binding = if (args.length > 1) resolveStateName(args[1]) else "showAlert";

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -2329,7 +2329,7 @@ class SwiftGenerator {
                  "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "buttonStyle" | "toggleStyle" | "pickerStyle" | "scrollIndicators" |
-                 "sheet" | "inspector" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
+                 "sheet" | "inspector" | "inspectorColumnWidth" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
                  "onAppear" | "onDisappear" | "task" | "navigationDestination" |
                  "onTapGesture" | "tint" | "badge" | "tag" |
                  "onAppearAction" | "taskAction" | "toolbarItem" |
@@ -2485,6 +2485,14 @@ class SwiftGenerator {
                 var pad = ind(indent + 1);
                 var contentSwift = if (args.length > 1) viewToSwift(args[1], indent + 2) else '${pad}    Text("Inspector")\n';
                 'inspector(isPresented: $$${binding}) {\n${contentSwift}${pad}}';
+            case "inspectorColumnWidth":
+                var mn = if (args.length > 0) extractConstant(args[0]) else null;
+                var id = if (args.length > 1) extractConstant(args[1]) else null;
+                var mx = if (args.length > 2) extractConstant(args[2]) else null;
+                if (mn == null) mn = "200";
+                if (id == null) id = "300";
+                if (mx == null) mx = "600";
+                'inspectorColumnWidth(min: ${mn}, ideal: ${id}, max: ${mx})';
             case "alert":
                 var title = if (args.length > 0) extractString(args[0]) else "Alert";
                 var binding = if (args.length > 1) resolveStateName(args[1]) else "showAlert";

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1037,6 +1037,32 @@ class SwiftGenerator {
                 }
                 return buf.toString();
 
+            case "LinearGradient":
+                // args[0] = TArrayDecl<ColorValue>, args[1] = startPoint String,
+                // args[2] = endPoint String.
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var start = args.length > 1 ? extractString(args[1]) : "top";
+                var end = args.length > 2 ? extractString(args[2]) : "bottom";
+                if (start == null) start = "top";
+                if (end == null) end = "bottom";
+                return '${pad}LinearGradient(colors: ${swiftColors}, startPoint: .${esc(start)}, endPoint: .${esc(end)})\n';
+
+            case "RadialGradient":
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var center = args.length > 1 ? extractString(args[1]) : "center";
+                var startR = args.length > 2 ? extractConstant(args[2]) : "0";
+                var endR = args.length > 3 ? extractConstant(args[3]) : "100";
+                if (center == null) center = "center";
+                if (startR == null) startR = "0";
+                if (endR == null) endR = "100";
+                return '${pad}RadialGradient(colors: ${swiftColors}, center: .${esc(center)}, startRadius: ${startR}, endRadius: ${endR})\n';
+
+            case "AngularGradient":
+                var swiftColors = extractColorArrayToSwift(args.length > 0 ? args[0] : null);
+                var center = args.length > 1 ? extractString(args[1]) : "center";
+                if (center == null) center = "center";
+                return '${pad}AngularGradient(colors: ${swiftColors}, center: .${esc(center)})\n';
+
             case "Spacer":
                 if (args.length > 0) {
                     var v = extractConstant(args[0]);
@@ -2235,6 +2261,26 @@ class SwiftGenerator {
     static function camel(s:String):String {
         if (s == null || s.length == 0) return s;
         return s.charAt(0).toLowerCase() + s.substr(1);
+    }
+
+    /** Translate a TArrayDecl of `ColorValue` enum constants into a
+        Swift literal `[.red, .blue, …]`. Used by the gradient
+        views. Unknown / non-enum entries fall through to
+        `.primary` to keep the array length matched. **/
+    static function extractColorArrayToSwift(expr:haxe.macro.Type.TypedExpr):String {
+        if (expr == null) return "[]";
+        var e = unwrap(expr);
+        switch (e.expr) {
+            case TArrayDecl(elems):
+                var parts:Array<String> = [];
+                for (el in elems) {
+                    var name = extractEnumName(el);
+                    parts.push(name != null ? '.${camel(name)}' : ".primary");
+                }
+                return '[${parts.join(", ")}]';
+            default:
+        }
+        return "[]";
     }
 
     static function templateToSwift(template:String):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -1819,7 +1819,8 @@ class SwiftGenerator {
     static function isModifier(name:String):Bool {
         return switch (name) {
             case "padding" | "font" | "foregroundColor" | "background" | "bold" | "italic" |
-                 "frame" | "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
+                 "frame" | "fillWidth" | "fillHeight" | "fillBoth" |
+                 "cornerRadius" | "opacity" | "navigationTitle" | "multilineTextAlignment" |
                  "disabled" | "overlay" | "shadow" | "lineLimit" | "textFieldStyle" |
                  "toggleStyle" | "pickerStyle" | "scrollIndicators" |
                  "sheet" | "alert" | "confirmationDialog" | "searchable" | "toolbar" | "animation" |
@@ -1866,6 +1867,15 @@ class SwiftGenerator {
                 if (args.length > 0) { var w = extractConstant(args[0]); if (w != null) parts.push('width: $w'); }
                 if (args.length > 1) { var h = extractConstant(args[1]); if (h != null) parts.push('height: $h'); }
                 'frame(${parts.join(", ")})';
+            // Stretch helpers — workarounds for SwiftUI containers that
+            // collapse to zero in layout contexts without a definite
+            // intrinsic size (notably `List` inside `.sheet` content).
+            case "fillWidth":
+                'frame(maxWidth: .infinity)';
+            case "fillHeight":
+                'frame(maxHeight: .infinity)';
+            case "fillBoth":
+                'frame(maxWidth: .infinity, maxHeight: .infinity)';
             case "disabled":
                 var v = if (args.length > 0) extractConstant(args[0]) else "true";
                 'disabled($v)';

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -31,7 +31,7 @@ enum ViewModifier {
         content behind it. Standard in macOS sidebars, popovers, and
         toolbars. **/
     BackgroundMaterial(style:sui.View.MaterialStyle);
-    Opacity(value:Float);
+    Opacity(value:Dynamic);
 
     // Shape
     CornerRadius(radius:Float);
@@ -92,6 +92,13 @@ enum ViewModifier {
     ScaleEffect(scale:Dynamic);
     RotationEffect(degrees:Dynamic);
     Offset(x:Dynamic, y:Dynamic);
+    /** Fraction-of-parent-size offset. Valid only inside a
+        `GeometryReader`; reads `proxy.size.{width,height}` from
+        the enclosing reader. **/
+    ProportionalOffset(xFraction:Dynamic, yFraction:Dynamic);
+    /** Fraction-of-parent-size frame. Like `ProportionalOffset`,
+        only valid inside a `GeometryReader`. **/
+    ProportionalFrame(widthFraction:Dynamic, heightFraction:Dynamic);
 
     // Image effects (accept Float for static or String for state-bound)
     Brightness(amount:Dynamic);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -22,6 +22,10 @@ enum ViewModifier {
     // Colors & Appearance
     ForegroundColor(color:ColorValue);
     Background(color:ColorValue);
+    /** Translucent SwiftUI Material as a background fill — picks up
+        content behind it. Standard in macOS sidebars, popovers, and
+        toolbars. **/
+    BackgroundMaterial(style:sui.View.MaterialStyle);
     Opacity(value:Float);
 
     // Shape

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -38,6 +38,7 @@ enum ViewModifier {
 
     // Styles
     TextFieldStyle(style:sui.View.TextFieldStyleValue);
+    ButtonStyle(style:sui.View.ButtonStyleValue);
 
     // Presentation
     Sheet(isPresentedBinding:Dynamic, content:sui.View);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -100,6 +100,14 @@ enum ViewModifier {
     // Interaction
     OnSubmit(actionId:Int);
     OnLongPressGesture(action:sui.state.StateAction);
+    /** SwiftUI `.onKeyPress(_:action:)` — runs a `StateAction` when
+        a key is pressed while this view (or a descendant) has
+        focus. The `key` follows the same naming convention as
+        `.keyboardShortcut` (single char or named special key:
+        `return`, `escape`, `delete`, `tab`, `space`,
+        `left` / `right` / `up` / `down`, `home`, `end`,
+        `pageup` / `pagedown`). **/
+    OnKeyPress(key:String, action:sui.state.StateAction);
 
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -56,6 +56,9 @@ enum ViewModifier {
         Standard pattern in Mac apps for "details about the current
         selection" (Pages, Numbers, Xcode). **/
     Inspector(isPresentedBinding:Dynamic, content:sui.View);
+    /** Width hint for the Inspector column: `min` / `ideal` / `max`.
+        Apply on the same view that owns the `.inspector(...)` call. **/
+    InspectorColumnWidth(min:Float, ideal:Float, max:Float);
     Alert(title:String, isPresentedBinding:Dynamic, message:Null<String>);
     ConfirmationDialog(title:String, isPresentedBinding:Dynamic, content:sui.View);
 

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -25,8 +25,8 @@ enum ViewModifier {
     // Colors & Appearance
     ForegroundColor(color:ColorValue);
     Background(color:ColorValue);
-    ForegroundHex(expr:String);
-    BackgroundHex(expr:String);
+    ForegroundHex(expr:Dynamic);
+    BackgroundHex(expr:Dynamic);
     Opacity(value:Float);
 
     // Shape

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -22,6 +22,8 @@ enum ViewModifier {
     // Colors & Appearance
     ForegroundColor(color:ColorValue);
     Background(color:ColorValue);
+    ForegroundHex(expr:String);
+    BackgroundHex(expr:String);
     Opacity(value:Float);
 
     // Shape

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -41,6 +41,11 @@ enum ViewModifier {
 
     // Presentation
     Sheet(isPresentedBinding:Dynamic, content:sui.View);
+    /** macOS-style trailing inspector pane — slides out from the
+        right edge of the window when its bound Bool is true.
+        Standard pattern in Mac apps for "details about the current
+        selection" (Pages, Numbers, Xcode). **/
+    Inspector(isPresentedBinding:Dynamic, content:sui.View);
     Alert(title:String, isPresentedBinding:Dynamic, message:Null<String>);
     ConfirmationDialog(title:String, isPresentedBinding:Dynamic, content:sui.View);
 

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -96,6 +96,9 @@ enum ViewModifier {
 
     // Accessibility
     AccessibilityLabel(label:String);
+    /** SwiftUI `.help("…")` — tooltip text shown on hover on macOS,
+        accessibility hint on iOS. **/
+    Help(text:String);
 
     // Interaction
     OnSubmit(actionId:Int);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -12,6 +12,9 @@ enum ViewModifier {
     Padding(value:Float);
     PaddingEdges(edges:Edge, value:Float);
     Frame(width:Null<Float>, height:Null<Float>, alignment:Null<Alignment>);
+    FillWidth;
+    FillHeight;
+    FillBoth;
 
     // Typography
     Font(style:FontStyle);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -100,6 +100,13 @@ enum ViewModifier {
     // Interaction
     OnSubmit(actionId:Int);
     OnLongPressGesture(action:sui.state.StateAction);
+    /** SwiftUI `.keyboardShortcut(_:, modifiers:)` — binds a keyboard
+        shortcut to the receiving view (typically a Button). The
+        `key` is a single character or one of the special-name
+        sentinels: "return", "escape", "delete", "tab", "space",
+        "left", "right", "up", "down". `modifiers` is any
+        combination of "command" / "option" / "control" / "shift". **/
+    KeyboardShortcut(key:String, modifiers:Array<String>);
 
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);

--- a/src/sui/modifiers/ViewModifier.hx
+++ b/src/sui/modifiers/ViewModifier.hx
@@ -106,6 +106,13 @@ enum ViewModifier {
     // Interaction
     OnSubmit(actionId:Int);
     OnLongPressGesture(action:sui.state.StateAction);
+    /** SwiftUI `.onChange(of:_:)` — fires a StateAction when the
+        named state value changes. Used to react to Picker / TextField
+        / Toggle selection updates without polling. **/
+    OnChange(stateName:String, action:sui.state.StateAction);
+
+    // Picker
+    PickerStyle(style:sui.View.PickerStyleValue);
 
     // Spacing
     FixedSize(horizontal:Bool, vertical:Bool);

--- a/src/sui/state/State.hx
+++ b/src/sui/state/State.hx
@@ -24,6 +24,10 @@ package sui.state;
 **/
 #if cpp
 @:cppFileCode('
+#include <clocale>
+#include <cstdio>
+#include <cstring>
+
 // State notification function pointer — set by the bridge at init time.
 // When no bridge is linked, this stays null and set() is a no-op for Swift.
 static void (*_hxsui_state_callback)(const char* key, const char* value) = nullptr;
@@ -34,6 +38,29 @@ extern "C" void haxe_bridge_register_state_fn(void (*cb)(const char*, const char
 
 void _hxsui_notify_swift(const char* key, const char* value) {
     if (_hxsui_state_callback) _hxsui_state_callback(key, value);
+}
+
+// Locale-neutral Float → string. The Haxe-bundled `Std.string(Float)`
+// goes through the C `printf` family, which honours `LC_NUMERIC`. On
+// a comma-decimal locale (fr_FR, de_DE, ru_RU, …) it emits "-57,2",
+// which Swift\'s locale-invariant `Double(_:)` parser then rejects,
+// so the value silently falls back to 0. Force the POSIX ("C")
+// locale just around the format call and restore the caller\'s
+// locale afterwards so we don\'t disturb the rest of the runtime.
+::String _hxsui_format_float_posix(double v) {
+    char savedLocale[128];
+    const char* current = std::setlocale(LC_NUMERIC, NULL);
+    if (current) {
+        std::strncpy(savedLocale, current, sizeof(savedLocale) - 1);
+        savedLocale[sizeof(savedLocale) - 1] = 0;
+    } else {
+        std::strcpy(savedLocale, "C");
+    }
+    std::setlocale(LC_NUMERIC, "C");
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.17g", v);
+    std::setlocale(LC_NUMERIC, savedLocale);
+    return ::String(buf);
 }
 ')
 #end
@@ -69,7 +96,9 @@ class State<T> {
         #if cpp
         if (this.name != "") {
             var k = this.name;
-            var v = if (Std.isOfType(initialValue, Array)) "" else Std.string(initialValue);
+            var v = if (Std.isOfType(initialValue, Array)) ""
+                else if (Std.isOfType(initialValue, Float)) _formatFloatPosix(cast initialValue)
+                else Std.string(initialValue);
             untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', k, v);
         }
         #end
@@ -86,8 +115,9 @@ class State<T> {
         }
         #if cpp
         var k = name;
-        // For arrays, send empty string — Swift reads data via shared memory
-        var v = if (Std.isOfType(newValue, Array)) "" else Std.string(newValue);
+        var v = if (Std.isOfType(newValue, Array)) ""
+            else if (Std.isOfType(newValue, Float)) _formatFloatPosix(cast newValue)
+            else Std.string(newValue);
         untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', k, v);
         #end
         return newValue;
@@ -246,4 +276,15 @@ class State<T> {
         untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', key, value);
         #end
     }
+
+    #if cpp
+    /** Format a Float in locale-neutral form via C++17 `std::to_chars`.
+        Used by the State setter to guarantee Swift's `Double(_:)`
+        parser accepts the result regardless of the system locale. **/
+    private static inline function _formatFloatPosix(v:Float):String {
+        var out:String = "";
+        untyped __cpp__('{0} = _hxsui_format_float_posix({1})', out, v);
+        return out;
+    }
+    #end
 }

--- a/src/sui/state/State.hx
+++ b/src/sui/state/State.hx
@@ -54,6 +54,25 @@ class State<T> {
         this.name = name != null ? name : "";
         if (this.name != "")
             _registry.set(this.name, this);
+        // Push the initial value across the bridge so AppState's
+        // Swift-side property — which the macro currently emits with a
+        // literal default (`""`, `false`, `0`, …) — picks up what Haxe
+        // intends. Without this, a `new State<Bool>(true, "isLoggedIn")`
+        // in the App constructor leaves Swift's `isLoggedIn` at `false`
+        // until the next mutation, which routinely causes the wrong
+        // initial view to render (re-login screen for an
+        // already-authenticated user, empty grids, …).
+        //
+        // Arrays go through the shared-memory bridge, so we still send
+        // an empty string — that bumps the version counter on the
+        // Swift side and triggers a fresh read.
+        #if cpp
+        if (this.name != "") {
+            var k = this.name;
+            var v = if (Std.isOfType(initialValue, Array)) "" else Std.string(initialValue);
+            untyped __cpp__('_hxsui_notify_swift({0}.utf8_str(), {1}.utf8_str())', k, v);
+        }
+        #end
     }
 
     function get_value():T {

--- a/src/sui/state/StateAction.hx
+++ b/src/sui/state/StateAction.hx
@@ -49,6 +49,18 @@ enum StateAction {
     BridgeCallLoading(state:Dynamic, loadingValue:String, functionName:String, args:Dynamic);
 
     /**
+        Call a `@:expose` function asynchronously and discard the
+        result. Use this for periodic ticks and other fire-and-forget
+        bridge calls where you don't want the return value to clobber
+        a state field.
+
+        ```haxe
+        BridgeCallVoid("tickNowLine", "")
+        ```
+    **/
+    BridgeCallVoid(functionName:String, args:Dynamic);
+
+    /**
         Wrap any StateAction in a SwiftUI `withAnimation` block.
 
         ```haxe
@@ -61,4 +73,21 @@ enum StateAction {
         ```
     **/
     Animated(action:StateAction, curve:AnimationCurve);
+
+    /**
+        Run `action` every `seconds` for as long as the view stays
+        attached. Used with `.taskAction(...)` for periodic refreshes
+        that don't depend on a user gesture (e.g. a clock indicator,
+        live data polling).
+
+        ```haxe
+        myView.taskAction(
+            StateAction.IntervalLoop(60, StateAction.BridgeCall(_, "tick", ""))
+        )
+        ```
+
+        Generates a `Task.sleep(_:)` loop guarded by `Task.isCancelled`
+        so the loop terminates when the view disappears.
+    **/
+    IntervalLoop(seconds:Float, action:StateAction);
 }

--- a/src/sui/state/StateOr.hx
+++ b/src/sui/state/StateOr.hx
@@ -21,4 +21,13 @@ abstract StateOr<T>(Dynamic) {
     @:from public static inline function fromState<T>(s:State<T>):StateOr<T> {
         return cast s;
     }
+
+    /** Legacy stringly-typed escape hatch — accepts an expression
+        the macro forwards into Swift verbatim (e.g.
+        `"dayEventStartFracs[i]"` to subscript an array state by the
+        enclosing `ForEach` index). Prefer the typed `State<T>` form
+        when the binding doesn't need an index. **/
+    @:from public static inline function fromString(s:String):StateOr<Float> {
+        return cast s;
+    }
 }

--- a/src/sui/ui/AngularGradient.hx
+++ b/src/sui/ui/AngularGradient.hx
@@ -1,0 +1,31 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    An angular (conic) gradient — colours laid out around a centre
+    point, sweeping a full circle. Maps to SwiftUI's
+    `AngularGradient`.
+
+    ```haxe
+    new AngularGradient(
+        [ColorValue.Red, ColorValue.Orange, ColorValue.Yellow, ColorValue.Green, ColorValue.Blue, ColorValue.Purple, ColorValue.Red],
+        "center"
+    )
+    ```
+
+    `center` is one of the unit-point strings (`"center"`,
+    `"top"`, `"topLeading"`, …).
+**/
+@:swiftView("AngularGradient")
+class AngularGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var center:String;
+
+    public function new(colors:Array<ColorValue>, center:String) {
+        super();
+        this.viewType = "AngularGradient";
+        this.colors = colors;
+        this.center = center;
+    }
+}

--- a/src/sui/ui/Capsule.hx
+++ b/src/sui/ui/Capsule.hx
@@ -1,0 +1,21 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A capsule (stadium / pill) shape primitive — like a rectangle
+    with fully rounded short edges. Maps to SwiftUI's `Capsule`.
+
+    ```haxe
+    new Capsule()
+        .frame(100, 24)
+        .foregroundColor(ColorValue.Accent)
+    ```
+**/
+@:swiftView("Capsule")
+class Capsule extends View {
+    public function new() {
+        super();
+        this.viewType = "Capsule";
+    }
+}

--- a/src/sui/ui/Circle.hx
+++ b/src/sui/ui/Circle.hx
@@ -1,0 +1,23 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A circular shape primitive. Maps to SwiftUI's `Circle`.
+
+    Fits inside the bounds of its container — give it a square
+    `.frame(...)` for a true circle.
+
+    ```haxe
+    new Circle()
+        .frame(20, 20)
+        .foregroundColor(ColorValue.Red)
+    ```
+**/
+@:swiftView("Circle")
+class Circle extends View {
+    public function new() {
+        super();
+        this.viewType = "Circle";
+    }
+}

--- a/src/sui/ui/CommandMenu.hx
+++ b/src/sui/ui/CommandMenu.hx
@@ -1,0 +1,43 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A top-level macOS menu-bar menu — appears next to File / Edit / View
+    / Help in the system menu bar. Maps to SwiftUI's `CommandMenu` and
+    is attached to the App scene via the `commands()` override.
+
+    Items are typically `Button`s (with `.keyboardShortcut(...)` so each
+    has an associated ⌘-shortcut) and `Divider`s between groups.
+    Nested `Menu`s aren't supported by `CommandMenu` directly — use
+    sub-`CommandMenu`s instead.
+
+    ```haxe
+    class MyApp extends sui.App {
+        override function commands():Array<CommandMenu> {
+            return [
+                new CommandMenu("Calendar", [
+                    new Button("New Event", null, newEventAction)
+                        .keyboardShortcut("n", ["command"]),
+                    new Button("Today", null, showTodayAction)
+                        .keyboardShortcut("t", ["command"]),
+                ]),
+            ];
+        }
+    }
+    ```
+
+    On iOS / iPadOS / tvOS the menu bar isn't shown, so `CommandMenu`s
+    are silently dropped by SwiftUI on those platforms.
+**/
+@:swiftView("CommandMenu")
+class CommandMenu extends View {
+    public var label:String;
+
+    public function new(@:swiftLabel("_") label:String, content:Array<View>) {
+        super();
+        this.viewType = "CommandMenu";
+        this.label = label;
+        this.children = content;
+    }
+}

--- a/src/sui/ui/Ellipse.hx
+++ b/src/sui/ui/Ellipse.hx
@@ -1,0 +1,22 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    An ellipse shape primitive — fills the bounds of its container,
+    so the aspect ratio is determined by `.frame(width, height)`.
+    Maps to SwiftUI's `Ellipse`.
+
+    ```haxe
+    new Ellipse()
+        .frame(100, 50)
+        .foregroundColor(ColorValue.Purple)
+    ```
+**/
+@:swiftView("Ellipse")
+class Ellipse extends View {
+    public function new() {
+        super();
+        this.viewType = "Ellipse";
+    }
+}

--- a/src/sui/ui/ForEach.hx
+++ b/src/sui/ui/ForEach.hx
@@ -6,45 +6,71 @@ import sui.View;
     Iterates over a state array and generates a view for each element.
     Maps to SwiftUI's `ForEach`.
 
-    Usage:
-    ```haxe
-    // Typed State reference (preferred):
-    new ForEach(todos, "i",
-        new Text("Item")
-    )
+    Two call shapes, both compiled by the SwiftGenerator macro:
 
-    // String name (still supported for backward compat):
-    new ForEach("todos", "i",
-        new Text("Item")
+    **Closure form (preferred)** — the iteration parameter is a Haxe
+    value, so references inside the body are type-checked at compile
+    time and SwiftUI receives the right expression without you having
+    to spell out the array subscript as a string. Modifiers like
+    `Text(item)` and `.tag(item)` detect the item ref and emit the
+    matching Swift expression.
+
+    ```haxe
+    new ForEach(colorOptions, item ->
+        new Text(item).tag(item)
     )
     ```
 
     Generates:
     ```swift
-    ForEach(0..<todos.count, id: \.self) { i in
-        Text("Item")
+    ForEach(0..<colorOptions.count, id: \.self) { item in
+        Text("\(appState.colorOptions[item])")
+            .tag(appState.colorOptions[item])
     }
     ```
 
-    Use `Text.withState("{todos[i].title}")` in the child view
-    to reference properties of each item.
+    **Legacy form (kept for backward compatibility)** — pass the
+    iteration variable name as a String and use string templating
+    inside the body view (`Text.withState("{name[i]}")`).
+
+    ```haxe
+    new ForEach(todos, "i",
+        Text.withState("{todos[i].title}")
+    )
+    ```
 **/
 class ForEach extends View {
     public var arrayName:Dynamic;
     public var itemName:String;
     public var itemView:View;
+    /** Closure-form builder, captured at runtime so the type-system
+        sees the param; the macro takes the typed-AST path instead. **/
+    public var builder:Dynamic;
 
     /**
         @param arrayName State<Array<T>> field reference or string name of the @State array variable
-        @param itemName  Name for the iteration variable in generated Swift
-        @param itemView  View to render for each item (use {arrayName[itemName].prop} for interpolation)
+        @param itemNameOrBuilder Either the iteration variable name (legacy form, takes a third argument) OR a `T -> View` closure that builds each row given the item value
+        @param itemView View to render — only required for the legacy 3-arg form
     **/
-    public function new(arrayName:Dynamic, itemName:String, itemView:View) {
+    public function new(arrayName:Dynamic, itemNameOrBuilder:Dynamic, ?itemView:View) {
         super();
         this.viewType = "ForEach";
         this.arrayName = arrayName;
-        this.itemName = itemName;
-        this.itemView = itemView;
-        this.children = [itemView];
+        if (itemView != null) {
+            this.itemName = itemNameOrBuilder;
+            this.itemView = itemView;
+            this.children = [itemView];
+        } else if (Reflect.isFunction(itemNameOrBuilder)) {
+            // Closure form — the macro inspects the typed AST.
+            this.builder = itemNameOrBuilder;
+            this.itemName = "item";
+            this.itemView = null;
+            this.children = [];
+        } else {
+            // String itemName but no itemView — degenerate, kept for safety.
+            this.itemName = itemNameOrBuilder;
+            this.itemView = null;
+            this.children = [];
+        }
     }
 }

--- a/src/sui/ui/GeometryReader.hx
+++ b/src/sui/ui/GeometryReader.hx
@@ -1,0 +1,43 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    Reports its parent-proposed size to its content via a SwiftUI
+    `GeometryProxy`. Maps to SwiftUI's `GeometryReader`.
+
+    Unlike most layout views, `GeometryReader` *claims the full
+    space* proposed by its parent — children inside it are
+    positioned in that space (default `.topLeading`). This makes it
+    ideal for things like a "now" line that needs to know the
+    rendered height of its container, or any view that wants to
+    position itself by fractions of the parent.
+
+    Inside a `GeometryReader`, the `.proportionalOffset(x, y)`
+    modifier interprets its arguments as `0…1` fractions of the
+    parent's measured size, so layout-precise positioning doesn't
+    need any compile-time pixel constants.
+
+    ```haxe
+    new GeometryReader(
+        new Rectangle()
+            .frame(null, 2)
+            .foregroundColor(ColorValue.Red)
+            // Move down by `nowMinuteFrac` × measured height.
+            .proportionalOffset(0.0, nowMinuteFrac)
+    )
+    ```
+
+    `GeometryReader` reports through a Swift identifier named
+    `proxy`; `.proportionalOffset` reads `proxy.size.width` and
+    `proxy.size.height` directly, so the modifier must live inside
+    a `GeometryReader` (it won't compile in a standalone view).
+**/
+@:swiftView("GeometryReader")
+class GeometryReader extends View {
+    public function new(content:View) {
+        super();
+        this.viewType = "GeometryReader";
+        this.children = [content];
+    }
+}

--- a/src/sui/ui/LinearGradient.hx
+++ b/src/sui/ui/LinearGradient.hx
@@ -1,0 +1,38 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A linear gradient — colours laid out along a straight line
+    between two unit points. Maps to SwiftUI's `LinearGradient`.
+
+    ```haxe
+    new LinearGradient(
+        [ColorValue.Blue, ColorValue.Purple],
+        "top",
+        "bottom"
+    )
+    ```
+
+    Common unit-point strings: `"top"`, `"bottom"`, `"leading"`,
+    `"trailing"`, `"topLeading"`, `"topTrailing"`,
+    `"bottomLeading"`, `"bottomTrailing"`, `"center"`.
+
+    Like all gradients, has no intrinsic size — use `.frame(...)`
+    or rely on the parent to size it. Often used as a `.background`
+    or inside a `.foregroundColor` style.
+**/
+@:swiftView("LinearGradient")
+class LinearGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var startPoint:String;
+    public var endPoint:String;
+
+    public function new(colors:Array<ColorValue>, startPoint:String, endPoint:String) {
+        super();
+        this.viewType = "LinearGradient";
+        this.colors = colors;
+        this.startPoint = startPoint;
+        this.endPoint = endPoint;
+    }
+}

--- a/src/sui/ui/Menu.hx
+++ b/src/sui/ui/Menu.hx
@@ -1,0 +1,33 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A drop-down menu containing buttons (or nested menus / dividers).
+    Maps to SwiftUI's `Menu`.
+
+    The typical use case is a toolbar dropdown — clicking the label
+    opens a popover with the actions. On macOS it adopts the system
+    `NSMenu` look; on iOS it's a popover sheet.
+
+    ```haxe
+    new Menu("Actions", [
+        new Button("New", null, newAction),
+        new Button("Open…", null, openAction),
+        new Button("Delete", null, deleteAction),
+    ])
+    ```
+
+    `Menu`s can be nested for sub-menus.
+**/
+@:swiftView("Menu")
+class Menu extends View {
+    public var label:String;
+
+    public function new(@:swiftLabel("_") label:String, content:Array<View>) {
+        super();
+        this.viewType = "Menu";
+        this.label = label;
+        this.children = content;
+    }
+}

--- a/src/sui/ui/RadialGradient.hx
+++ b/src/sui/ui/RadialGradient.hx
@@ -1,0 +1,37 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A radial gradient — colours laid out in concentric rings from a
+    centre point. Maps to SwiftUI's `RadialGradient`.
+
+    ```haxe
+    new RadialGradient(
+        [ColorValue.Yellow, ColorValue.Red],
+        "center",
+        0,
+        100
+    )
+    ```
+
+    `center` is one of the unit-point strings (`"center"`,
+    `"top"`, `"topLeading"`, …). `startRadius` / `endRadius` are
+    in points.
+**/
+@:swiftView("RadialGradient")
+class RadialGradient extends View {
+    public var colors:Array<ColorValue>;
+    public var center:String;
+    public var startRadius:Float;
+    public var endRadius:Float;
+
+    public function new(colors:Array<ColorValue>, center:String, startRadius:Float, endRadius:Float) {
+        super();
+        this.viewType = "RadialGradient";
+        this.colors = colors;
+        this.center = center;
+        this.startRadius = startRadius;
+        this.endRadius = endRadius;
+    }
+}

--- a/src/sui/ui/Rectangle.hx
+++ b/src/sui/ui/Rectangle.hx
@@ -1,0 +1,24 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A rectangular shape primitive. Maps to SwiftUI's `Rectangle`.
+
+    Like all SwiftUI shapes, it has no intrinsic size — give it one
+    via `.frame(...)` or rely on the parent layout to size it.
+    Fill with `.foregroundColor(...)` or `.foregroundHex(...)`.
+
+    ```haxe
+    new Rectangle()
+        .frame(100, 50)
+        .foregroundColor(ColorValue.Blue)
+    ```
+**/
+@:swiftView("Rectangle")
+class Rectangle extends View {
+    public function new() {
+        super();
+        this.viewType = "Rectangle";
+    }
+}

--- a/src/sui/ui/ShareLink.hx
+++ b/src/sui/ui/ShareLink.hx
@@ -1,0 +1,36 @@
+package sui.ui;
+
+import sui.View;
+
+/**
+    A button that triggers the system share sheet. Maps to SwiftUI's
+    `ShareLink(item:)`.
+
+    The `item` is what gets shared — for v1 this is always a `String`,
+    which SwiftUI auto-detects as a URL when it parses as one, or as
+    plain text otherwise. Passing an optional `label` lets you
+    override the default share-arrow icon.
+
+    ```haxe
+    // Default UI (system share-arrow icon)
+    new ShareLink("https://example.com")
+
+    // Custom label
+    new ShareLink("https://example.com", "Share this link")
+    ```
+
+    On macOS opens the system Share menu; on iOS / iPadOS / visionOS
+    opens the activity controller (UIActivityViewController).
+**/
+@:swiftView("ShareLink")
+class ShareLink extends View {
+    public var item:String;
+    public var label:Null<String>;
+
+    public function new(@:swiftLabel("item") item:String, ?label:String) {
+        super();
+        this.viewType = "ShareLink";
+        this.item = item;
+        this.label = label;
+    }
+}


### PR DESCRIPTION
**Draft / stacked**: this branch carries the full `local/calendar-build` integration so the dependent feature branches are visible — the contribution-specific commit is the **last** one (`Add GeometryReader, proportional layout, IntervalLoop, alignment emission`). Once the prerequisite PRs land on `main`, this PR's diff shrinks to that single commit and is ready for review on its own.

## Contribution

Layout primitives that let a caller position child views by *fraction* of a measured container without compile-time pixel constants.

### New view
- `GeometryReader` — claims its parent-proposed size and exposes a `proxy` to its content. Mirrors SwiftUI's behaviour exactly.

### New modifiers (valid only inside a `GeometryReader`)
- `.proportionalOffset(xFrac, yFrac)` — translates by `frac × measured size`. GR anchors at `.topLeading`, so fraction 0 = top/leading edge.
- `.proportionalFrame(widthFrac, heightFrac)` — sizes to a fraction of the parent. A negative literal on an axis drops that dimension so the view keeps its intrinsic size.

### New StateActions
- `IntervalLoop(seconds, action)` — emits a SwiftUI `Task.sleep` loop guarded by `Task.isCancelled`. Lets `.taskAction` express "tick this state every N seconds" without raw Swift strings.
- `BridgeCallVoid(fnName, args)` — like `BridgeCall` but discards the return value, for fire-and-forget ticks.

### Codegen plumbing
- `VStack`/`HStack`/`ZStack` now forward their `alignment` enum argument (previously silently dropped).
- `.frame(width, height, alignment)` likewise emits the alignment argument.
- `Opacity` accepts `StateOr<Float>` (was `Float`-only) so visibility can be reactive.
- `resolveModifierValue` wraps every TString / TField / TLocal in the `__APPSTATE__` placeholder, so a State reference passed to `.offset`, `.scaleEffect`, `.proportionalOffset` etc. lands as `appState.X` in the generated Swift regardless of syntactic context.
- The `bodyWithAppState` rewriter handles `name == …` / `name != …` equality patterns so a scalar `nowHour == i` comparison emits as `appState.nowHour == i`.

## Stacks on (all currently-open `feat/*` PRs)

`feat/button-style`, `feat/menu-view`, `feat/command-menu`, `feat/settings-scene`, `feat/keyboard-shortcut`, `feat/help-tooltip`, `feat/share-link`, `feat/inspector-modifier`, `feat/on-key-press`, `feat/material-backgrounds`, `feat/shape-primitives`, `feat/gradients`, `feat/inspector-column-width` (#80), `feat/commands-scene-state-rewrite` (#81), `feat/state-locale-neutral-float` (#82), `feat/color-alpha-hex` (#83), `feat/stateor-from-string` (#84).

## Verification

Drives the Day + Week timeline of the `clients/calendar-mac` client: events positioned by `proportionalOffset(dayIdx/7, startMin/1440)`, sized by `proportionalFrame(1/7, duration/1440)`, "now" line by `proportionalOffset(0, nowGridFrac)`, per-minute ticker by `IntervalLoop(60, BridgeCallVoid("tickNowLine", ""))`.