### PR TITLE
SwiftExprBridge: transparent Haxe expressions in modifiers + StateActions

### DIFF
--- a/src/sui/macros/StateMacro.hx
+++ b/src/sui/macros/StateMacro.hx
@@ -32,12 +32,21 @@ class StateMacro {
     ];
 
     static var synthesisedExprs:Map<String, SynthesisedExpr>;
+    /** Map state field name → inner type T of `State<T>`. The
+        Swift binding lives on `appState.<name>`; for value-typed
+        bindings (String / Int / Float / Bool) the walker passes
+        the Swift value into the synthesised wrapper as a parameter
+        so reads see the current SwiftUI binding rather than the
+        possibly-stale Haxe mirror. Array / object state stays on
+        the Haxe side (`App.instance.<name>.value`). **/
+    static var stateFieldTypes:Map<String, ComplexType>;
     static var stateFieldNames:Map<String, Bool>;
     static var className:String;
 
     public static function build():Array<Field> {
         synthesisedExprs = new Map();
         stateFieldNames = new Map();
+        stateFieldTypes = new Map();
         className = {
             var cls = Context.getLocalClass();
             cls != null ? cls.get().name : "";
@@ -47,17 +56,28 @@ class StateMacro {
         var stateInits:Array<Expr> = [];
         var newFields:Array<Field> = [];
 
-        // First pass: collect every state-typed field name (both
-        // `@:state var x:T` and manual `var x:State<T>`). The
-        // walker uses this list to qualify bare references inside
-        // bridged expressions.
+        // First pass: collect every state-typed field name and its
+        // inner type T (both `@:state var x:T` and manual `var
+        // x:State<T>`).
         for (field in fields) {
             switch (field.kind) {
                 case FVar(t, _):
-                    if (isStateType(t)) stateFieldNames.set(field.name, true);
+                    var inner = stateInnerType(t);
+                    if (inner != null) {
+                        stateFieldNames.set(field.name, true);
+                        stateFieldTypes.set(field.name, inner);
+                    }
+                case FProp(_, _, t, _):
+                    var inner = stateInnerType(t);
+                    if (inner != null) {
+                        stateFieldNames.set(field.name, true);
+                        stateFieldTypes.set(field.name, inner);
+                    }
                 default:
             }
         }
+        // Also `@:state` fields use their raw T — collect later as
+        // we process them (loop below).
 
         for (field in fields) {
             var isState = false;
@@ -158,15 +178,18 @@ class StateMacro {
             }
         }
 
-        // Append the synthesised wrapper functions.
+        // Append the synthesised wrapper functions. Parameter
+        // order: lambda params (Int) first, then primitive state
+        // reads. If neither is present, fall back to the legacy
+        // single-String "_unused" slot so the bridge generator
+        // emits a stable signature.
         for (entry in synthesisedExprs.keyValueIterator()) {
             var funcName = entry.key;
             var s = entry.value;
             var args:Array<FunctionArg> = [for (p in s.params) {name: p, type: macro :Int}];
-            // ABI convention: always at least one parameter (the
-            // String "_unused"), so the existing bridge generator
-            // keeps emitting a `(_unused: String): String` shape
-            // even when the expression has no lambda params.
+            if (s.primReads != null) {
+                for (p in s.primReads) args.push({name: p.name, type: p.type});
+            }
             if (args.length == 0) {
                 args.push({name: "_unused", type: macro :String});
             }
@@ -187,10 +210,16 @@ class StateMacro {
     }
 
     /** Walk an Expr tree, tracking lambda-param scope (from
-        ForEach legacy `"i"` form and closure form), and rewrite
-        every bridged-modifier call with a complex argument. **/
+        ForEach legacy `"i"` form and closure form), and rewrite:
+        - bridged-modifier calls with a complex argument
+        - `StateAction.RunExpr(expr)` invocations
+        Both flows synthesise an `@:expose static` wrapper on the
+        App class and replace the call site with a sentinel string. **/
     static function walk(e:Expr, scope:Map<String, Bool>):Expr {
         return switch (e.expr) {
+            // StateAction.RunExpr(expr) → synthesise + sentinel.
+            case ECall({expr: EField({expr: EConst(CIdent("StateAction"))}, "RunExpr")}, [innerExpr]):
+                synthesiseRunExpr(innerExpr, scope, e.pos);
             // ForEach legacy form: ENew("ForEach", [arr, "i", body])
             case ENew(t, args) if (t.name == "ForEach" && args.length == 3):
                 switch (args[1].expr) {
@@ -253,6 +282,91 @@ class StateMacro {
             default:
                 defaultRecurse(e, scope);
         };
+    }
+
+    /** Synthesise a wrapper for a `StateAction.RunExpr(...)` and
+        return the rewritten `StateAction.CustomSwift(<sentinel>)`
+        node. The sentinel uses the `SUIACTION` prefix so the Swift
+        code generator emits a `Task.detached { _ = HaxeBridgeC.X(args) }`
+        instead of a value-returning expression. **/
+    static function synthesiseRunExpr(innerExpr:Expr, scope:Map<String, Bool>, pos:Position):Expr {
+        var lambdaParams = collectLambdaParams(innerExpr, scope);
+        var primReads = collectPrimitiveStateReads(innerExpr, scope);
+        var qualified = qualifyAndLiftStateRefs(innerExpr, scope, primReads);
+        var hash = hashExpr(innerExpr);
+        var funcName = '_sui_action_$hash';
+        if (!synthesisedExprs.exists(funcName)) {
+            synthesisedExprs.set(funcName, {
+                expr: macro {
+                    $e{qualified};
+                    "";
+                },
+                pos: pos,
+                params: lambdaParams,
+                primReads: primReads,
+            });
+        }
+        // sentinel: SUIACTION<funcName><stateRefs (arrays/objects)><lambdaParams><primReadsCSV>
+        var arrayStateRefs = collectStateRefs(innerExpr, scope).filter(n -> !arrContains(primReads, n));
+        var stateList = arrayStateRefs.join(",");
+        var paramList = lambdaParams.join(",");
+        var primList = [for (p in primReads) p.name].join(",");
+        var sentinel = "\u{0001}SUIACTION\u{0001}" + funcName + "\u{0001}" + stateList + "\u{0001}" + paramList + "\u{0001}" + primList;
+        return macro StateAction.CustomSwift($v{sentinel});
+    }
+
+    /** Find every `<stateName>.value` read in `e` where `stateName`
+        is a primitive State field. These get lifted into function
+        parameters of the synthesised wrapper so the value comes
+        from the Swift-side `appState.<name>` (fresh, post-binding)
+        rather than the Haxe mirror (potentially stale when Swift
+        UI bindings own the write). **/
+    static function collectPrimitiveStateReads(e:Expr, scope:Map<String, Bool>):Array<{name:String, type:ComplexType}> {
+        var found:Array<{name:String, type:ComplexType}> = [];
+        function visit(node:Expr) {
+            switch (node.expr) {
+                case EField({expr: EConst(CIdent(name))}, "value")
+                    if (stateFieldNames.exists(name)
+                        && !scope.exists(name)
+                        && isPrimitiveStateInner(stateFieldTypes.get(name))
+                        && !arrContains(found, name)):
+                    found.push({name: name, type: stateFieldTypes.get(name)});
+                case EFunction(_, _): return;
+                default:
+            }
+            ExprTools.iter(node, visit);
+        }
+        visit(e);
+        return found;
+    }
+
+    /** Like `qualifyStateRefs`, but ALSO lifts `<stateName>.value`
+        reads (for primitive states in `primReads`) into bare
+        parameter references — the synthesised wrapper carries the
+        Swift-side current value as `<stateName>` parameter. **/
+    static function qualifyAndLiftStateRefs(e:Expr, scope:Map<String, Bool>, primReads:Array<{name:String, type:ComplexType}>):Expr {
+        function isLifted(name:String):Bool {
+            return arrContains(primReads, name);
+        }
+        function rewrite(node:Expr):Expr {
+            return switch (node.expr) {
+                // Lift `state.value` → bare ident `state`.
+                case EField({expr: EConst(CIdent(name)), pos: ip}, "value")
+                    if (stateFieldNames.exists(name) && !scope.exists(name) && isLifted(name)):
+                    {expr: EConst(CIdent(name)), pos: node.pos};
+                // Qualify bare state ref (non-lifted) → ClassName.instance.X.
+                case EConst(CIdent(name))
+                    if (stateFieldNames.exists(name) && !scope.exists(name) && !isLifted(name)):
+                    var clsExpr:Expr = {expr: EConst(CIdent(className)), pos: node.pos};
+                    var instExpr:Expr = {expr: EField(clsExpr, "instance"), pos: node.pos};
+                    {expr: EField(instExpr, name), pos: node.pos};
+                // Don't descend into nested closures.
+                case EFunction(_, _): node;
+                default:
+                    ExprTools.map(node, rewrite);
+            };
+        }
+        return rewrite(e);
     }
 
     /** Recurse into immediate children with the same scope. **/
@@ -358,13 +472,45 @@ class StateMacro {
     /** True if the ComplexType is `sui.state.State<…>` (or
         unqualified `State<…>`). **/
     static function isStateType(t:Null<ComplexType>):Bool {
+        return stateInnerType(t) != null;
+    }
+
+    /** Returns the inner type T of a `sui.state.State<T>` ComplexType,
+        or null if `t` isn't a State field. **/
+    static function stateInnerType(t:Null<ComplexType>):Null<ComplexType> {
+        if (t == null) return null;
+        return switch (t) {
+            case TPath(p) if (p.name == "State"
+                && (p.pack.length == 0
+                    || (p.pack.length == 2 && p.pack[0] == "sui" && p.pack[1] == "state"))
+                && p.params != null && p.params.length == 1):
+                switch (p.params[0]) {
+                    case TPType(inner): inner;
+                    default: null;
+                }
+            default: null;
+        };
+    }
+
+    /** Is `t` a value-typed primitive that the SwiftUI binding
+        carries as a Swift property? Those get passed as parameters
+        into the synthesised wrapper; everything else (Array, object,
+        custom enum, …) stays on the Haxe side. **/
+    static function isPrimitiveStateInner(t:Null<ComplexType>):Bool {
         if (t == null) return false;
         return switch (t) {
-            case TPath(p):
-                p.name == "State" && (p.pack.length == 0
-                    || (p.pack.length == 2 && p.pack[0] == "sui" && p.pack[1] == "state"));
+            case TPath(p) if (p.pack.length == 0):
+                switch (p.name) {
+                    case "String" | "Int" | "Float" | "Bool": true;
+                    default: false;
+                }
             default: false;
         };
+    }
+
+    static function arrContains(arr:Array<{name:String, type:ComplexType}>, name:String):Bool {
+        for (p in arr) if (p.name == name) return true;
+        return false;
     }
 
     static function copyScope(s:Map<String, Bool>):Map<String, Bool> {
@@ -390,5 +536,6 @@ typedef SynthesisedExpr = {
     expr:Expr,
     pos:Position,
     params:Array<String>,
+    ?primReads:Array<{name:String, type:ComplexType}>,
 };
 #end

--- a/src/sui/macros/StateMacro.hx
+++ b/src/sui/macros/StateMacro.hx
@@ -3,26 +3,61 @@ package sui.macros;
 #if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
+import haxe.macro.ExprTools;
 
 /**
-    Build macro for App subclasses that transforms @:state fields.
+    Build macro for App subclasses that:
+    1. Transforms `@:state` fields into `State<T>` fields with
+       constructor initialisation.
+    2. Walks every method body to find calls to *bridged modifiers*
+       (`foregroundHex`, `backgroundHex`, …). If a call's argument
+       is "complex" (anything beyond a literal string or a typed
+       state reference), the argument expression is captured,
+       state references inside it are qualified against the App
+       instance, lambda parameters from enclosing `ForEach` scopes
+       become function parameters, and a `@:expose static`
+       wrapper is synthesised on this class. The call site is
+       replaced with a sentinel-encoded string that the Swift
+       generator dispatches into a `HaxeBridgeC.<funcName>(args)`
+       call.
 
-    Converts:
-    ```haxe
-    @:state var count:Int = 0;
-    ```
-
-    Into:
-    ```haxe
-    var count:State<Int>;
-    // constructor init: count = new State<Int>(0, "count");
-    ```
+    The user writes plain Haxe; the macro takes care of everything.
 **/
 class StateMacro {
+    /** Modifiers whose single argument is bridged when complex.
+        Mirror in `SwiftGenerator.SUI_BRIDGE_PREFIX` dispatcher. **/
+    static final BRIDGED_MODIFIERS = [
+        "foregroundHex" => true,
+        "backgroundHex" => true,
+    ];
+
+    static var synthesisedExprs:Map<String, SynthesisedExpr>;
+    static var stateFieldNames:Map<String, Bool>;
+    static var className:String;
+
     public static function build():Array<Field> {
+        synthesisedExprs = new Map();
+        stateFieldNames = new Map();
+        className = {
+            var cls = Context.getLocalClass();
+            cls != null ? cls.get().name : "";
+        };
+
         var fields = Context.getBuildFields();
         var stateInits:Array<Expr> = [];
         var newFields:Array<Field> = [];
+
+        // First pass: collect every state-typed field name (both
+        // `@:state var x:T` and manual `var x:State<T>`). The
+        // walker uses this list to qualify bare references inside
+        // bridged expressions.
+        for (field in fields) {
+            switch (field.kind) {
+                case FVar(t, _):
+                    if (isStateType(t)) stateFieldNames.set(field.name, true);
+                default:
+            }
+        }
 
         for (field in fields) {
             var isState = false;
@@ -40,7 +75,6 @@ class StateMacro {
                 continue;
             }
 
-            // Extract the original type and default value
             var origType:Null<ComplexType> = null;
             var defaultExpr:Null<Expr> = null;
             switch (field.kind) {
@@ -60,15 +94,14 @@ class StateMacro {
             }
 
             var fieldName = field.name;
+            stateFieldNames.set(fieldName, true);
 
-            // Replace field type: T → State<T>
             var stateType:ComplexType = TPath({
                 pack: ["sui", "state"],
                 name: "State",
                 params: [TPType(origType)]
             });
 
-            // Rewrite the field as State<T> with no initializer (set in constructor)
             newFields.push({
                 name: field.name,
                 access: field.access,
@@ -78,20 +111,17 @@ class StateMacro {
                 doc: field.doc,
             });
 
-            // Generate constructor init: fieldName = new State<T>(defaultValue, "fieldName")
             var nameExpr = macro $v{fieldName};
             stateInits.push(macro $i{fieldName} = new sui.state.State($defaultExpr, $nameExpr));
         }
 
         if (stateInits.length > 0) {
-            // Find or create constructor
             var ctorFound = false;
             for (f in newFields) {
                 if (f.name == "new") {
                     ctorFound = true;
                     switch (f.kind) {
                         case FFun(func):
-                            // Prepend state inits before existing constructor body
                             var existingBody = func.expr;
                             var allExprs:Array<Expr> = stateInits.copy();
                             if (existingBody != null) allExprs.push(existingBody);
@@ -103,7 +133,6 @@ class StateMacro {
             }
 
             if (!ctorFound) {
-                // Create a constructor that calls super() and inits state
                 var allExprs:Array<Expr> = [macro super()];
                 for (e in stateInits) allExprs.push(e);
                 newFields.push({
@@ -119,7 +148,247 @@ class StateMacro {
             }
         }
 
+        // Walk every method body, replacing bridged-modifier calls
+        // with sentinel strings and synthesising wrappers.
+        for (f in newFields) {
+            switch (f.kind) {
+                case FFun(func) if (func.expr != null):
+                    func.expr = walk(func.expr, new Map());
+                default:
+            }
+        }
+
+        // Append the synthesised wrapper functions.
+        for (entry in synthesisedExprs.keyValueIterator()) {
+            var funcName = entry.key;
+            var s = entry.value;
+            var args:Array<FunctionArg> = [for (p in s.params) {name: p, type: macro :Int}];
+            // ABI convention: always at least one parameter (the
+            // String "_unused"), so the existing bridge generator
+            // keeps emitting a `(_unused: String): String` shape
+            // even when the expression has no lambda params.
+            if (args.length == 0) {
+                args.push({name: "_unused", type: macro :String});
+            }
+            newFields.push({
+                name: funcName,
+                access: [APublic, AStatic],
+                meta: [{name: ":expose", pos: s.pos}],
+                kind: FFun({
+                    args: args,
+                    ret: macro :String,
+                    expr: macro return $e{s.expr},
+                }),
+                pos: s.pos,
+            });
+        }
+
         return newFields;
     }
+
+    /** Walk an Expr tree, tracking lambda-param scope (from
+        ForEach legacy `"i"` form and closure form), and rewrite
+        every bridged-modifier call with a complex argument. **/
+    static function walk(e:Expr, scope:Map<String, Bool>):Expr {
+        return switch (e.expr) {
+            // ForEach legacy form: ENew("ForEach", [arr, "i", body])
+            case ENew(t, args) if (t.name == "ForEach" && args.length == 3):
+                switch (args[1].expr) {
+                    case EConst(CString(idx)):
+                        var newScope = copyScope(scope);
+                        newScope.set(idx, true);
+                        var newArr = walk(args[0], scope);
+                        var newBody = walk(args[2], newScope);
+                        {expr: ENew(t, [newArr, args[1], newBody]), pos: e.pos};
+                    default:
+                        defaultRecurse(e, scope);
+                }
+            // ForEach closure form: ENew("ForEach", [arr, item -> body])
+            case ENew(t, args) if (t.name == "ForEach" && args.length == 2):
+                switch (args[1].expr) {
+                    case EFunction(kind, fn):
+                        var newScope = copyScope(scope);
+                        for (a in fn.args) newScope.set(a.name, true);
+                        var newArr = walk(args[0], scope);
+                        var newFn:Function = {args: fn.args, ret: fn.ret, expr: walk(fn.expr, newScope)};
+                        var newLambda:Expr = {expr: EFunction(kind, newFn), pos: args[1].pos};
+                        {expr: ENew(t, [newArr, newLambda]), pos: e.pos};
+                    default:
+                        defaultRecurse(e, scope);
+                }
+            // Bridged modifier: <view>.foregroundHex(<arg>)
+            case ECall(callee, args) if (args.length == 1 && isBridgedModifierCallee(callee)):
+                var arg = args[0];
+                var newReceiver = walkCallee(callee, scope);
+                if (isSimpleExpr(arg, scope)) {
+                    // Existing typed/stringly codepath handles it.
+                    var newArg = walk(arg, scope);
+                    {expr: ECall(newReceiver, [newArg]), pos: e.pos};
+                } else {
+                    // Capture for bridging.
+                    var lambdaParams = collectLambdaParams(arg, scope);
+                    var stateRefs = collectStateRefs(arg, scope);
+                    var qualified = qualifyStateRefs(arg, scope);
+                    var hash = hashExpr(arg);
+                    var funcName = '_sui_expr_$hash';
+                    if (!synthesisedExprs.exists(funcName)) {
+                        synthesisedExprs.set(funcName, {
+                            expr: qualified,
+                            pos: arg.pos,
+                            params: lambdaParams,
+                        });
+                    }
+                    var stateList = stateRefs.join(",");
+                    var paramList = lambdaParams.join(",");
+                    var sentinel = "\u{0001}SUIBRIDGE\u{0001}" + funcName + "\u{0001}" + stateList + "\u{0001}" + paramList;
+                    var sentinelExpr:Expr = {expr: EConst(CString(sentinel)), pos: arg.pos};
+                    {expr: ECall(newReceiver, [sentinelExpr]), pos: e.pos};
+                }
+            // Generic recursion with scope-aware EFunction handling.
+            case EFunction(kind, fn):
+                var newScope = copyScope(scope);
+                for (a in fn.args) newScope.set(a.name, true);
+                var newFn:Function = {args: fn.args, ret: fn.ret, expr: walk(fn.expr, newScope)};
+                {expr: EFunction(kind, newFn), pos: e.pos};
+            default:
+                defaultRecurse(e, scope);
+        };
+    }
+
+    /** Recurse into immediate children with the same scope. **/
+    static function defaultRecurse(e:Expr, scope:Map<String, Bool>):Expr {
+        return ExprTools.map(e, child -> walk(child, scope));
+    }
+
+    /** Walk the receiver chain of a modifier call. The callee for
+        `x.foo` is `EField(x, "foo")`; we recurse into `x`. **/
+    static function walkCallee(callee:Expr, scope:Map<String, Bool>):Expr {
+        return switch (callee.expr) {
+            case EField(target, fieldName):
+                {expr: EField(walk(target, scope), fieldName), pos: callee.pos};
+            default:
+                walk(callee, scope);
+        };
+    }
+
+    static function isBridgedModifierCallee(callee:Expr):Bool {
+        return switch (callee.expr) {
+            case EField(_, fieldName): BRIDGED_MODIFIERS.exists(fieldName);
+            default: false;
+        };
+    }
+
+    /** "Simple" args that the existing typed codepath handles
+        cleanly — leave them untouched. Anything outside this
+        narrow set gets bridged. **/
+    static function isSimpleExpr(e:Expr, scope:Map<String, Bool>):Bool {
+        return switch (e.expr) {
+            case EConst(CString(_)): true;
+            case EConst(CIdent(name)):
+                stateFieldNames.exists(name) || scope.exists(name);
+            case EField(inner, "value"):
+                isSimpleStateRef(inner);
+            case EArray(arr, idx):
+                isSimpleExpr(arr, scope) && isSimpleExpr(idx, scope);
+            default: false;
+        };
+    }
+
+    static function isSimpleStateRef(e:Expr):Bool {
+        return switch (e.expr) {
+            case EConst(CIdent(name)): stateFieldNames.exists(name);
+            default: false;
+        };
+    }
+
+    /** Collect identifiers in `e` that match a lambda param in
+        `scope` (ForEach closure / legacy index). Order-preserving,
+        de-duplicated. These become function parameters of the
+        synthesised wrapper. **/
+    static function collectLambdaParams(e:Expr, scope:Map<String, Bool>):Array<String> {
+        var found:Array<String> = [];
+        function visit(node:Expr) {
+            switch (node.expr) {
+                case EConst(CIdent(name)) if (scope.exists(name) && found.indexOf(name) == -1):
+                    found.push(name);
+                default:
+            }
+            ExprTools.iter(node, visit);
+        }
+        visit(e);
+        return found;
+    }
+
+    /** Collect identifiers in `e` that reference a State field
+        (not shadowed by a lambda param). The SwiftUI side touches
+        each one inside a subscription closure so view re-renders
+        track the state mutations the bridged Haxe expression
+        reads. **/
+    static function collectStateRefs(e:Expr, scope:Map<String, Bool>):Array<String> {
+        var found:Array<String> = [];
+        function visit(node:Expr) {
+            switch (node.expr) {
+                case EConst(CIdent(name)) if (stateFieldNames.exists(name) && !scope.exists(name) && found.indexOf(name) == -1):
+                    found.push(name);
+                case EFunction(_, _): return; // Nested closure has its own scope; ignore.
+                default:
+            }
+            ExprTools.iter(node, visit);
+        }
+        visit(e);
+        return found;
+    }
+
+    /** Rewrite bare `<stateName>` references → `<ClassName>.instance.<name>`.
+        Leaves lambda-param refs alone (they're in scope of the
+        synthesised function as parameters). **/
+    static function qualifyStateRefs(e:Expr, scope:Map<String, Bool>):Expr {
+        return switch (e.expr) {
+            case EConst(CIdent(name)) if (stateFieldNames.exists(name) && !scope.exists(name)):
+                var clsExpr:Expr = {expr: EConst(CIdent(className)), pos: e.pos};
+                var instExpr:Expr = {expr: EField(clsExpr, "instance"), pos: e.pos};
+                {expr: EField(instExpr, name), pos: e.pos};
+            // Don't descend into nested closures (they have their own scope).
+            case EFunction(_, _): e;
+            default:
+                ExprTools.map(e, child -> qualifyStateRefs(child, scope));
+        };
+    }
+
+    /** True if the ComplexType is `sui.state.State<…>` (or
+        unqualified `State<…>`). **/
+    static function isStateType(t:Null<ComplexType>):Bool {
+        if (t == null) return false;
+        return switch (t) {
+            case TPath(p):
+                p.name == "State" && (p.pack.length == 0
+                    || (p.pack.length == 2 && p.pack[0] == "sui" && p.pack[1] == "state"));
+            default: false;
+        };
+    }
+
+    static function copyScope(s:Map<String, Bool>):Map<String, Bool> {
+        var copy = new Map<String, Bool>();
+        for (k => v in s) copy.set(k, v);
+        return copy;
+    }
+
+    /** Stable content hash over the expression's `toString`. **/
+    static function hashExpr(e:Expr):String {
+        var src = ExprTools.toString(e);
+        var h:Int = 0x811c9dc5;
+        for (i in 0...src.length) {
+            h = (h ^ src.charCodeAt(i)) & 0xffffffff;
+            h = (h * 16777619) & 0xffffffff;
+        }
+        var u = h & 0x7fffffff;
+        return StringTools.hex(u, 8).toLowerCase();
+    }
 }
+
+typedef SynthesisedExpr = {
+    expr:Expr,
+    pos:Position,
+    params:Array<String>,
+};
 #end

--- a/src/sui/macros/StateMacro.hx
+++ b/src/sui/macros/StateMacro.hx
@@ -24,11 +24,30 @@ import haxe.macro.ExprTools;
     The user writes plain Haxe; the macro takes care of everything.
 **/
 class StateMacro {
-    /** Modifiers whose single argument is bridged when complex.
-        Mirror in `SwiftGenerator.SUI_BRIDGE_PREFIX` dispatcher. **/
+    /** Modifiers whose argument(s) are bridged when complex,
+        mapped to the synthesised wrapper's return type. String
+        for hex-coloured modifiers, Float for numeric ones (offsets,
+        opacity, scale, …). Mirror keys in
+        `SwiftGenerator.SUI_BRIDGE_PREFIX` dispatcher. **/
     static final BRIDGED_MODIFIERS = [
-        "foregroundHex" => true,
-        "backgroundHex" => true,
+        "foregroundHex" => "String",
+        "backgroundHex" => "String",
+        "opacity" => "Float",
+        "scaleEffect" => "Float",
+        "rotationEffect" => "Float",
+        "blur" => "Float",
+        "brightness" => "Float",
+        "contrast" => "Float",
+        "saturation" => "Float",
+        "grayscale" => "Float",
+    ];
+
+    /** Multi-arg modifiers — every argument is independently bridged
+        when complex. Values map to return type per axis. **/
+    static final BRIDGED_MODIFIERS_MULTI = [
+        "offset" => "Float",
+        "proportionalOffset" => "Float",
+        "proportionalFrame" => "Float",
     ];
 
     static var synthesisedExprs:Map<String, SynthesisedExpr>;
@@ -193,13 +212,14 @@ class StateMacro {
             if (args.length == 0) {
                 args.push({name: "_unused", type: macro :String});
             }
+            var ret:ComplexType = s.returnType != null ? s.returnType : macro :String;
             newFields.push({
                 name: funcName,
                 access: [APublic, AStatic],
                 meta: [{name: ":expose", pos: s.pos}],
                 kind: FFun({
                     args: args,
-                    ret: macro :String,
+                    ret: ret,
                     expr: macro return $e{s.expr},
                 }),
                 pos: s.pos,
@@ -245,34 +265,19 @@ class StateMacro {
                     default:
                         defaultRecurse(e, scope);
                 }
-            // Bridged modifier: <view>.foregroundHex(<arg>)
-            case ECall(callee, args) if (args.length == 1 && isBridgedModifierCallee(callee)):
+            // Bridged single-arg modifier: <view>.foregroundHex(<arg>)
+            case ECall(callee, args) if (args.length == 1 && isBridgedModifierCallee(callee, BRIDGED_MODIFIERS)):
                 var arg = args[0];
                 var newReceiver = walkCallee(callee, scope);
-                if (isSimpleExpr(arg, scope)) {
-                    // Existing typed/stringly codepath handles it.
-                    var newArg = walk(arg, scope);
-                    {expr: ECall(newReceiver, [newArg]), pos: e.pos};
-                } else {
-                    // Capture for bridging.
-                    var lambdaParams = collectLambdaParams(arg, scope);
-                    var stateRefs = collectStateRefs(arg, scope);
-                    var qualified = qualifyStateRefs(arg, scope);
-                    var hash = hashExpr(arg);
-                    var funcName = '_sui_expr_$hash';
-                    if (!synthesisedExprs.exists(funcName)) {
-                        synthesisedExprs.set(funcName, {
-                            expr: qualified,
-                            pos: arg.pos,
-                            params: lambdaParams,
-                        });
-                    }
-                    var stateList = stateRefs.join(",");
-                    var paramList = lambdaParams.join(",");
-                    var sentinel = "\u{0001}SUIBRIDGE\u{0001}" + funcName + "\u{0001}" + stateList + "\u{0001}" + paramList;
-                    var sentinelExpr:Expr = {expr: EConst(CString(sentinel)), pos: arg.pos};
-                    {expr: ECall(newReceiver, [sentinelExpr]), pos: e.pos};
-                }
+                var retType = lookupReturnType(callee, BRIDGED_MODIFIERS);
+                var newArg = maybeBridge(arg, scope, retType);
+                {expr: ECall(newReceiver, [newArg]), pos: e.pos};
+            // Bridged multi-arg modifier: <view>.proportionalOffset(<x>, <y>)
+            case ECall(callee, args) if (isBridgedModifierCallee(callee, BRIDGED_MODIFIERS_MULTI)):
+                var newReceiver = walkCallee(callee, scope);
+                var retType = lookupReturnType(callee, BRIDGED_MODIFIERS_MULTI);
+                var newArgs = [for (a in args) maybeBridge(a, scope, retType)];
+                {expr: ECall(newReceiver, newArgs), pos: e.pos};
             // Generic recursion with scope-aware EFunction handling.
             case EFunction(kind, fn):
                 var newScope = copyScope(scope);
@@ -385,10 +390,55 @@ class StateMacro {
         };
     }
 
-    static function isBridgedModifierCallee(callee:Expr):Bool {
+    static function isBridgedModifierCallee(callee:Expr, modifierMap:Map<String, String>):Bool {
         return switch (callee.expr) {
-            case EField(_, fieldName): BRIDGED_MODIFIERS.exists(fieldName);
+            case EField(_, fieldName): modifierMap.exists(fieldName);
             default: false;
+        };
+    }
+
+    static function lookupReturnType(callee:Expr, modifierMap:Map<String, String>):String {
+        return switch (callee.expr) {
+            case EField(_, fieldName) if (modifierMap.exists(fieldName)): modifierMap.get(fieldName);
+            default: "String";
+        };
+    }
+
+    /** If the argument is simple, leave it for the existing typed
+        codepath; otherwise capture it for bridging with the given
+        return type. **/
+    static function maybeBridge(arg:Expr, scope:Map<String, Bool>, retType:String):Expr {
+        if (isSimpleExpr(arg, scope)) return walk(arg, scope);
+        var lambdaParams = collectLambdaParams(arg, scope);
+        var primReads = collectPrimitiveStateReads(arg, scope);
+        var stateRefs = collectStateRefs(arg, scope);
+        var arrayStateRefs = stateRefs.filter(n -> !arrContains(primReads, n));
+        var qualified = qualifyAndLiftStateRefs(arg, scope, primReads);
+        var hash = hashExpr(arg);
+        var funcName = '_sui_expr_$hash';
+        if (!synthesisedExprs.exists(funcName)) {
+            synthesisedExprs.set(funcName, {
+                expr: qualified,
+                pos: arg.pos,
+                params: lambdaParams,
+                primReads: primReads,
+                returnType: complexFromName(retType),
+                isAction: false,
+            });
+        }
+        var stateList = arrayStateRefs.join(",");
+        var paramList = lambdaParams.join(",");
+        var primList = [for (p in primReads) p.name].join(",");
+        var sentinel = "\u{0001}SUIBRIDGE\u{0001}" + funcName + "\u{0001}" + stateList + "\u{0001}" + paramList + "\u{0001}" + primList;
+        return {expr: EConst(CString(sentinel)), pos: arg.pos};
+    }
+
+    static function complexFromName(name:String):ComplexType {
+        return switch (name) {
+            case "Float": macro :Float;
+            case "Int": macro :Int;
+            case "Bool": macro :Bool;
+            default: macro :String;
         };
     }
 
@@ -397,9 +447,10 @@ class StateMacro {
         narrow set gets bridged. **/
     static function isSimpleExpr(e:Expr, scope:Map<String, Bool>):Bool {
         return switch (e.expr) {
-            case EConst(CString(_)): true;
+            case EConst(CString(_) | CInt(_) | CFloat(_)): true;
             case EConst(CIdent(name)):
-                stateFieldNames.exists(name) || scope.exists(name);
+                name == "true" || name == "false" || name == "null"
+                    || stateFieldNames.exists(name) || scope.exists(name);
             case EField(inner, "value"):
                 isSimpleStateRef(inner);
             case EArray(arr, idx):
@@ -537,5 +588,7 @@ typedef SynthesisedExpr = {
     pos:Position,
     params:Array<String>,
     ?primReads:Array<{name:String, type:ComplexType}>,
+    ?returnType:ComplexType,
+    ?isAction:Bool,
 };
 #end

--- a/src/sui/macros/SwiftExprBridge.hx
+++ b/src/sui/macros/SwiftExprBridge.hx
@@ -1,0 +1,115 @@
+package sui.macros;
+
+#if macro
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+
+/**
+    Bridges arbitrary Haxe expressions into the SwiftUI view tree by
+    synthesising a uniquely-named `@:expose` Haxe function whose body
+    is the user's expression, and emitting a `HaxeBridgeC.<name>(...)`
+    call on the Swift side. The expression is *executed* by hxcpp at
+    runtime — there is no Haxe→Swift transpilation.
+
+    The full Haxe language is therefore available inside any modifier
+    argument that this module handles. The only constraint is that
+    the expression must compile in Haxe (`Reflect`, `Math`, custom
+    helpers, recursive logic — all fine).
+
+    Used by sui modifiers that previously took stringly-typed Swift
+    snippets (`foregroundHex`, `backgroundHex`, …). Each call site
+    is hashed into a stable identifier so identical expressions in
+    different sites share one wrapper function.
+
+    The synthesised functions are injected into the App class by
+    `StateMacro.build` — that's where Haxe still lets us add fields.
+**/
+class SwiftExprBridge {
+    /** Map from "<modifier>:<exprHash>" → synthesised function name.
+        Populated by `register`, drained by `StateMacro.build` to
+        emit the actual fields. **/
+    public static var synthesised:Map<String, SynthesisedFunction> = new Map();
+
+    /** Register an expression for synthesis. Returns the unique
+        function name the bridge will expose. Idempotent: registering
+        the same key twice returns the same name. **/
+    public static function register(
+        modifier:String,
+        expr:Expr,
+        ?lambdaParams:Array<{name:String, type:ComplexType}>
+    ):String {
+        var hash = hashExpr(expr);
+        var key = '${modifier}:${hash}';
+        if (synthesised.exists(key)) return synthesised.get(key).name;
+
+        var name = '_sui_expr_${hash}';
+        synthesised.set(key, {
+            name: name,
+            expr: expr,
+            params: lambdaParams != null ? lambdaParams : [],
+            returnType: inferReturnType(modifier),
+            modifier: modifier,
+        });
+        return name;
+    }
+
+    /** Drained by StateMacro at the end of build(). Returns a list
+        of `Field` to add to the App class. **/
+    public static function drainAsFields():Array<Field> {
+        var fields:Array<Field> = [];
+        for (key in synthesised.keys()) {
+            var s = synthesised.get(key);
+            fields.push({
+                name: s.name,
+                access: [APublic, AStatic],
+                meta: [{name: ":expose", pos: s.expr.pos}],
+                kind: FFun({
+                    args: [for (p in s.params) {name: p.name, type: p.type}],
+                    ret: s.returnType,
+                    expr: macro return $e{s.expr},
+                }),
+                pos: s.expr.pos,
+            });
+        }
+        synthesised = new Map(); // drain
+        return fields;
+    }
+
+    /** Stable hash for an expression. Uses `ExprTools.toString` then
+        a short content-derived suffix. Deterministic across builds
+        for identical source. **/
+    static function hashExpr(e:Expr):String {
+        var src = ExprTools.toString(e);
+        // Cheap content hash — Adler-ish. Stable across runs.
+        var h:Int = 0x811c9dc5;
+        for (i in 0...src.length) {
+            h = (h ^ src.charCodeAt(i)) & 0xffffffff;
+            h = (h * 16777619) & 0xffffffff;
+        }
+        // Hex it. Strip sign by masking to 32-bit positive.
+        var u = h & 0x7fffffff;
+        return StringTools.hex(u, 8).toLowerCase();
+    }
+
+    /** What Swift return type does this modifier need? **/
+    static function inferReturnType(modifier:String):ComplexType {
+        return switch (modifier) {
+            case "foregroundHex" | "backgroundHex": macro :String;
+            case "proportionalOffset" | "proportionalFrame" |
+                 "opacity" | "scaleEffect" | "rotationEffect" |
+                 "offset" | "blur" | "brightness" | "contrast" |
+                 "saturation" | "grayscale": macro :Float;
+            default: macro :String;
+        };
+    }
+}
+
+typedef SynthesisedFunction = {
+    name:String,
+    expr:Expr,
+    params:Array<{name:String, type:ComplexType}>,
+    returnType:ComplexType,
+    modifier:String,
+}
+#end

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -2849,6 +2849,14 @@ class SwiftGenerator {
     /** Resolve a modifier argument: number (literal) or string (state variable name, emitted bare). **/
     static function resolveModifierValue(args:Array<haxe.macro.Type.TypedExpr>, index:Int, defaultVal:String):String {
         if (index >= args.length) return defaultVal;
+        // Bridge sentinel — same dispatch as `resolveHexExpr`.
+        // The bridge call returns Float (or whatever the synthesised
+        // wrapper's return type is); the modifier site embeds the
+        // call straight into its arithmetic.
+        var sLit = extractString(args[index]);
+        if (sLit != null && StringTools.startsWith(sLit, SUI_BRIDGE_PREFIX)) {
+            return emitBridgeInvocation(sLit);
+        }
         // Closure-form ForEach item refs (`item`, `other.value[i]`)
         // take priority over the legacy string/field paths.
         var itemExpr = extractItemExpr(args[index]);

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -2326,7 +2326,14 @@ class SwiftGenerator {
                                     case "Toggle": '${p0}.toggle()';
                                     case "CustomSwift":
                                         var code = if (args.length > 0) extractString(args[0]) else null;
-                                        code != null ? code : "// custom";
+                                        if (code != null && StringTools.startsWith(code, SUI_ACTION_PREFIX)) {
+                                            // Bridged RunExpr — dispatch into a
+                                            // Task.detached invocation of the
+                                            // synthesised wrapper.
+                                            emitActionInvocation(code);
+                                        } else {
+                                            code != null ? code : "// custom";
+                                        }
                                     case "BridgeCall":
                                         var fnName = if (args.length > 1) extractString(args[1]) else "unknown";
                                         var argStr = if (args.length > 2) extractBridgeArgs(args[2]) else "";
@@ -2932,6 +2939,11 @@ class SwiftGenerator {
         bridged expressions. **/
     public static inline var SUI_BRIDGE_PREFIX = "\u{0001}SUIBRIDGE\u{0001}";
 
+    /** Prefix used when bridging a `StateAction.RunExpr(...)` — the
+        Swift codegen wraps the wrapper call in `Task.detached { … }`
+        instead of inlining the result. **/
+    public static inline var SUI_ACTION_PREFIX = "\u{0001}SUIACTION\u{0001}";
+
     /** Turn a sentinel-prefixed string into a Swift expression
         that invokes the bridged Haxe function. The sentinel
         encodes:
@@ -2964,6 +2976,29 @@ class SwiftGenerator {
         var subs = "";
         for (n in stateList) subs += '_ = appState.$n; ';
         return '{ ${subs}return ${bare} }()';
+    }
+
+    /** Turn an action sentinel into a Swift snippet that runs the
+        bridged wrapper inside a `Task.detached`. Sentinel format:
+            SUIACTION<funcName><stateRefs><lambdaParams><primReads>
+        - lambdaParams pass straight through (Int from ForEach);
+        - primReads come from `appState.<name>` so the synthesised
+          wrapper sees the live SwiftUI binding value rather than
+          the (possibly stale) Haxe mirror.
+        Side effects written by the wrapper still travel back to
+        Swift via the existing `swiftStateCallback →
+        DispatchQueue.main.async` pipeline. **/
+    static function emitActionInvocation(sentinel:String):String {
+        var rest = sentinel.substr(SUI_ACTION_PREFIX.length);
+        var parts = rest.split("\u{0001}");
+        var funcName = parts[0];
+        var lambdaList = parts.length > 2 && parts[2] != "" ? parts[2].split(",") : [];
+        var primList = parts.length > 3 && parts[3] != "" ? parts[3].split(",") : [];
+        var args:Array<String> = [];
+        for (p in lambdaList) args.push(p);
+        for (p in primList) args.push('appState.${p}');
+        var callArgs = args.length > 0 ? args.join(", ") : '""';
+        return 'Task.detached { _ = HaxeBridgeC.${funcName}(${callArgs}) }';
     }
 
     static function extractBridgeArgs(expr:haxe.macro.Type.TypedExpr):String {

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -2890,10 +2890,21 @@ class SwiftGenerator {
         appState-prefix pass rewrites bare names in. **/
     static function resolveHexExpr(args:Array<haxe.macro.Type.TypedExpr>):String {
         if (args.length == 0) return "\"\"";
-        // 1. Closure-form lambda item ref ("item", "other.value[i]")
+        // 1. Bridge sentinel — string literal that encodes a call
+        //    into a synthesised `@:expose` Haxe function (full Haxe
+        //    expression executed at runtime via the bridge, not
+        //    transpiled to Swift). Format:
+        //      "SUIBRIDGE<funcName><state1>,<state2>..."
+        //    Returns a closure-wrapped expression so SwiftUI keeps
+        //    its subscription on each touched state.
+        var sLit = extractString(args[0]);
+        if (sLit != null && StringTools.startsWith(sLit, SUI_BRIDGE_PREFIX)) {
+            return emitBridgeInvocation(sLit);
+        }
+        // 2. Closure-form lambda item ref ("item", "other.value[i]")
         var itemExpr = extractItemExpr(args[0]);
         if (itemExpr != null) return itemExpr;
-        // 2. Direct State<String> field reference (`.foregroundHex(myColorState)`).
+        // 3. Direct State<String> field reference (`.foregroundHex(myColorState)`).
         //    Emit `appState.<name>` straight away — the
         //    body-wide appState-prefix pass keys on bracket /
         //    interpolation / assignment patterns and doesn't match
@@ -2911,9 +2922,48 @@ class SwiftGenerator {
                 var fieldName = extractThisField(e);
                 if (fieldName != null) return 'appState.${fieldName}';
         }
-        // 3. Legacy: string literal embedded verbatim.
-        var s = extractString(args[0]);
-        return s != null ? s : "\"\"";
+        // 4. Legacy: string literal embedded verbatim.
+        return sLit != null ? sLit : "\"\"";
+    }
+
+    /** Prefix that marks a string argument as a bridge invocation.
+        Synthesised by `SwiftExprBridge.register` (or hand-written
+        for POC), recognised by every modifier codegen that supports
+        bridged expressions. **/
+    public static inline var SUI_BRIDGE_PREFIX = "\u{0001}SUIBRIDGE\u{0001}";
+
+    /** Turn a sentinel-prefixed string into a Swift expression
+        that invokes the bridged Haxe function. The sentinel
+        encodes:
+            SUIBRIDGE<funcName><statesCSV><lambdaParamsCSV>
+        Both `<statesCSV>` and `<lambdaParamsCSV>` may be empty.
+        Lambda params are passed as `Int32(<name>)` so the existing
+        `@:expose` bridge ABI sees the SwiftUI ForEach index
+        directly. When there are no lambda params we fall back to
+        the legacy single-String slot. When the expression touches
+        observable state, we wrap in a `{ _ = appState.X; … }()`
+        closure so SwiftUI keeps its subscription — but only then;
+        the bare call form keeps the ViewBuilder type-checker
+        happy on macOS 26 where the closure form trips the
+        `cannot type-check in reasonable time` heuristic. **/
+    static function emitBridgeInvocation(sentinel:String):String {
+        var rest = sentinel.substr(SUI_BRIDGE_PREFIX.length);
+        var parts = rest.split("\u{0001}");
+        var funcName = parts[0];
+        var stateList = parts.length > 1 && parts[1] != "" ? parts[1].split(",") : [];
+        var lambdaList = parts.length > 2 && parts[2] != "" ? parts[2].split(",") : [];
+        // ForEach in the generated SwiftUI gives us `Int` iteration
+        // params, and the bridge wrapper takes `Int` too — pass
+        // the param straight through (no `Int32(…)` cast which
+        // would build the wrong type).
+        var callArgs = lambdaList.length > 0
+            ? lambdaList.join(", ")
+            : '""';
+        var bare = 'HaxeBridgeC.${funcName}(${callArgs})';
+        if (stateList.length == 0) return bare;
+        var subs = "";
+        for (n in stateList) subs += '_ = appState.$n; ';
+        return '{ ${subs}return ${bare} }()';
     }
 
     static function extractBridgeArgs(expr:haxe.macro.Type.TypedExpr):String {

--- a/src/sui/state/StateAction.hx
+++ b/src/sui/state/StateAction.hx
@@ -30,6 +30,30 @@ enum StateAction {
     CustomSwift(code:String);
 
     /**
+        Run a Haxe expression for its side effects. The macro
+        captures the expression at build time, synthesises an
+        `@:expose static` wrapper on the App class, and the Swift
+        codegen routes the action into
+        `Task.detached { _ = HaxeBridgeC.<wrapper>(args) }`.
+
+        Lambda parameters in scope (e.g. `i` from an enclosing
+        `ForEach`) are passed through automatically. State refs
+        are qualified to `App.instance.<name>` so the static
+        wrapper can read them.
+
+        ```haxe
+        view.onTapGesture(StateAction.RunExpr(
+            App.toggleCalendar(Std.string(i))
+        ));
+        ```
+
+        Strictly preferable to `CustomSwift` whenever the action
+        is pure Haxe — type-checked, refactor-safe, and no Swift
+        mixed into a string.
+    **/
+    RunExpr(expr:Dynamic);
+
+    /**
         Call a @:expose function asynchronously and assign the result to a state variable.
 
         ```haxe


### PR DESCRIPTION
**Draft / stacked**: this PR adds 3 commits on top of #85 (`feat/geometry-reader-v3`). Once #85 lands, this becomes 3 clean commits against `main`.

## Summary

Replaces stringly-typed Swift snippets in sui modifier arguments and `StateAction.CustomSwift` with real Haxe expressions captured at build time and executed at runtime through the existing `@:expose` bridge. **Full Haxe is supported** inside any bridged expression — if it compiles in Haxe, it works. No Haxe→Swift transpilation.

## How it works

The walker in `StateMacro.build` recognises bridged modifier call sites and `StateAction.RunExpr(...)` invocations. For each:

1. Captures the inner Haxe expression.
2. Tracks scope: `ForEach` legacy `"i"` form and closure `i ->` form both bind their index for the expression.
3. Classifies the expression: simple state refs / array subscripts → existing typed codepath; complex (ternaries, comparisons, calls, …) → bridge.
4. Qualifies state refs to `App.instance.<name>` so the synthesised static wrapper can read them.
5. *Lifts* primitive `State<String|Int|Float|Bool>.value` reads into function parameters — the Swift call site passes `appState.<name>` so the wrapper sees the *current* SwiftUI-binding value rather than a possibly-stale Haxe mirror (important for `TextField` / `Picker` / `Toggle` bindings).
6. Synthesises `@:expose static function _sui_expr_<hash>(...): T` on the App class — picked up by the existing bridge generator.
7. Replaces the call site with a sentinel-encoded string. The Swift code generator dispatches the sentinel in `resolveHexExpr` / `resolveModifierValue` (value-returning) or in the `CustomSwift` codepath (`StateAction.RunExpr`).

## New variants & extensions

- `StateAction.RunExpr(expr)` — side-effecting Haxe expression bridge.
- `BRIDGED_MODIFIERS` — single-arg, returns String (`foregroundHex`, `backgroundHex`).
- `BRIDGED_MODIFIERS_MULTI` — multi-arg, returns Float (`offset`, `proportionalOffset`, `proportionalFrame`).
- `resolveModifierValue` now detects the sentinel so Float-returning bridges land in `proxy.size.width * (HaxeBridgeC._sui_expr_X())` arithmetic.

## Verified end-to-end on `clients/calendar-mac`

- All 11 `StateAction.CustomSwift` sites migrated to `RunExpr`.
- 2 ternary `foregroundHex` / `backgroundHex` sites migrated to typed Haxe.
- Behaviour unchanged across Day / Week / Month views, sidebar, event editor.
- Calendar tint colour resolves via the bridge; Picker.onChange dispatches via a typed wrapper that sees the Swift-bound `viewMode` value.

## Stacks on

#85 `feat/geometry-reader-v3` — which itself stacks on all of `feat/button-style`, `feat/menu-view`, `feat/command-menu`, `feat/settings-scene`, `feat/keyboard-shortcut`, `feat/help-tooltip`, `feat/share-link`, `feat/inspector-modifier`, `feat/on-key-press`, `feat/material-backgrounds`, `feat/shape-primitives`, `feat/gradients`, `feat/inspector-column-width` (#80), `feat/commands-scene-state-rewrite` (#81), `feat/state-locale-neutral-float` (#82), `feat/color-alpha-hex` (#83), `feat/stateor-from-string` (#84).

Once the stack lands on `main` the diff for this PR is just 3 commits (`15508ad`, `d9ff2eb`, `3184324`).