### PR TITLE
Dynamic renderer: walk the view tree at runtime

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -17,6 +17,7 @@
 - [Components](components.md)
 - [Animations](animations.md)
 - [Bridge](bridge.md)
+- [Dynamic Renderer](dynamic-renderer.md)
 - [Native Extensions](native-extensions.md)
 - [CLI Reference](cli.md)
 - [Platforms](platforms.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,7 @@ haxelib run sui <command> [options]
 | `--release` | Build in Release configuration |
 | `--verbose` / `-v` | Show xcodebuild output |
 | `--xcode-only` | Generate Xcode project without building |
+| `--watch` | Build the [dynamic renderer](dynamic-renderer.md) (runtime tree walk) instead of compiled Swift |
 
 ## Examples
 

--- a/docs/dynamic-renderer.md
+++ b/docs/dynamic-renderer.md
@@ -1,0 +1,174 @@
+# Dynamic Renderer
+
+sui normally **compiles** your view tree to Swift ahead of time: the macro reads
+`body()` at build time and emits static SwiftUI. The **dynamic renderer** flips
+that around &mdash; it walks the Haxe view tree at **runtime** and rebuilds
+SwiftUI from it, with no per-view codegen.
+
+That makes sui usable as a **host for a UI that isn't known at compile time**: a
+hot-reload loop, or a renderer driven by a live protocol (this is how rsx2ui's
+native A2UI renderer is built &mdash; a WebSocket feeds surfaces that become a
+sui view tree at runtime).
+
+Enable it with `--watch`:
+
+```bash
+sui build macos --watch
+```
+
+## How it works
+
+Instead of generating Swift per view, sui compiles a fixed **`DynamicView.swift`**
+that walks the tree recursively through a C bridge into the running hxcpp
+runtime. Your `body()` runs at runtime, produces a `View` tree, and each node is
+read on demand.
+
+```mermaid
+flowchart TD
+    A["SwiftUI: HotReloadRootView"] --> B["viewnode_get_root()"]
+    B --> C["ViewNodeBridge (Haxe): _root = app.body()"]
+    A --> D["DynamicView(node): switch on viewType"]
+    D --> E["viewnode_get_type / _child / _text / _property …"]
+    E --> C
+    D --> F["recurse into children"]
+    F --> D
+```
+
+Three layers:
+
+- **`DynamicView.swift`** (framework) &mdash; the recursive renderer. A `ViewNode`
+  wraps an opaque pointer to a Haxe `View`; `DynamicView` switches on its
+  `viewType` and maps it to the SwiftUI equivalent, recursing into children and
+  applying the modifier chain.
+- **`ViewNodeBridgeC.cpp` / `.h`** (framework) &mdash; the C bridge. Each accessor
+  registers the calling thread's stack with the hxcpp GC, calls the matching
+  `sui.runtime.ViewNodeBridge` static through its **direct hxcpp symbol**, and
+  returns a primitive or an opaque node pointer.
+- **`sui.runtime.ViewNodeBridge`** (framework, Haxe) &mdash; holds the app and the
+  current root, and exposes typed accessors over a `View` (`getViewType`,
+  `getChildCount`, `getChild`, `getTextContent`, `getStringProperty`,
+  `getModifierType`, …). It is `@:keep`: nothing in Haxe references it, so DCE
+  would otherwise strip it.
+
+## Bootstrap
+
+The static bridge boots from `haxe_bridge_init`. The dynamic renderer instead
+generates a small **`SuiBootC.cpp`** (the macro knows the concrete app class):
+
+```cpp
+extern "C" void viewnode_boot(void) {
+    // hx::Boot() + __boot_all() once, then:
+    auto app = ::YourApp_obj::__new();
+    ::sui::runtime::ViewNodeBridge_obj::setApp(app);  // runs app.body()
+}
+```
+
+`HotReloadRootView` calls `viewnode_boot()` exactly once (a lazily-initialised
+Swift global) before the first traversal, so `viewnode_get_root()` always sees an
+initialised runtime.
+
+## The render loop
+
+The tree is not static: something outside SwiftUI mutates it (a reload, an
+incoming protocol message). The renderer polls on the **main thread** and
+rebuilds only when something changed.
+
+```mermaid
+flowchart LR
+    T["SwiftUI Timer (main)"] --> P["viewnode_poll()"]
+    P --> D["ViewNodeBridge.poll(): delegate() → rebuild()?"]
+    D -->|changed| R["reloadCount++ (withAnimation)"]
+    R --> RE["DynamicView re-reads the tree"]
+```
+
+Register a poll delegate from your app; return `true` when the tree should
+rebuild:
+
+```haxe
+ViewNodeBridge.setPoll(() -> myQueue.drainAndApply());  // Void -> Bool
+```
+
+`poll()` runs the delegate and calls `rebuild()` (re-invokes `app.body()`) when
+it returns true. Bumps are wrapped in `withAnimation`, so with **stable node
+identities** SwiftUI interpolates layout changes instead of snapping.
+
+### Stable identity
+
+By default a rebuild tears the tree down and rebuilds it &mdash; input focus is
+lost, nothing animates. Tag each node with a `"nodeId"` property (any stable
+string) and `DynamicView` uses it as the SwiftUI identity, so the framework diffs
+across rebuilds: text fields keep focus, and moved elements animate.
+
+```haxe
+var v = new sui.ui.Text(label);
+v.properties.set("nodeId", stableId);   // survive rebuilds
+```
+
+## Input and actions back
+
+Two sinks let native controls and gestures report back into your Haxe app.
+
+**Data sink** &mdash; a native input (TextField, Toggle, Slider…) writes a value
+at a path:
+
+```haxe
+ViewNodeBridge.setDataSink((path, value) -> model.set(path, value));
+```
+
+sui's editable controls call `viewnode_set_data(path, value)` on change, which
+routes here. Mark the node with `path`/`value` properties for the control to use.
+
+**Action sink** &mdash; the renderer fires a named action with a JSON extra
+context (e.g. a drag-and-drop drop):
+
+```haxe
+ViewNodeBridge.setActionSink((name, extraJson) -> dispatch(name, extraJson));
+```
+
+Buttons built at runtime dispatch differently: their closure sits on the live
+tree (a GC root), so `viewnode_invoke_action(node)` calls it **directly** &mdash;
+no id indirection, unlike the static bridge.
+
+## Theming
+
+A native host can take an app-provided accent (e.g. a surface's brand colour):
+
+```haxe
+ViewNodeBridge.setAccent("#7c3aed");   // hex; "" = platform default
+```
+
+`HotReloadRootView` reads it via `viewnode_theme_accent()` and applies `.tint`,
+so native controls pick up the brand.
+
+## C entrypoints
+
+The bridge surface, all `extern "C"`:
+
+| Function | Purpose |
+|---|---|
+| `viewnode_boot()` | Boot hxcpp + register the app (generated `SuiBootC.cpp`). |
+| `viewnode_poll()` | Pump the poll delegate; returns 1 if the tree changed. |
+| `viewnode_rebuild()` | Re-run `app.body()`. |
+| `viewnode_get_root()` | Opaque pointer to the root node. |
+| `viewnode_get_type` / `_child_count` / `_get_child` | Tree traversal. |
+| `viewnode_get_text` / `_get_property` | Node content. |
+| `viewnode_get_button_label` / `_invoke_action` | Buttons (direct dispatch). |
+| `viewnode_modifier_count` / `_type` / `_float` / `_string` | Modifier chain. |
+| `viewnode_set_data(path, value)` | Input edit → data sink. |
+| `viewnode_fire_action(name, extraJson)` | Renderer action → action sink. |
+| `viewnode_theme_accent()` | The accent to tint controls with. |
+
+## What the build wires up
+
+Under `--watch`, the CLI treats the app as a native-bridge build:
+
+- compiles the hxcpp static library (`libhaxe.a`) plus `ViewNodeBridgeC.cpp` and
+  the generated `SuiBootC.cpp`;
+- copies `DynamicView.swift` and points `ContentView` at `HotReloadRootView`;
+- emits an umbrella bridging header and the link flags.
+
+It works without any action closures (the static bridge is suppressed in this
+mode) &mdash; the ViewNode bridge and direct dispatch replace it.
+
+> **See also:** the [Bridge](bridge.md) doc covers the *static* bridge used by
+> normal (compiled) apps. The dynamic renderer is the runtime counterpart.

--- a/examples/dynamic-hello/build.hxml
+++ b/examples/dynamic-hello/build.hxml
@@ -1,0 +1,6 @@
+-cp src
+-cp ../../src
+-lib hxcpp
+--macro sui.macros.SwiftGenerator.register()
+-main DynamicHello
+-cpp build/cpp

--- a/examples/dynamic-hello/src/DynamicHello.hx
+++ b/examples/dynamic-hello/src/DynamicHello.hx
@@ -1,0 +1,42 @@
+import sui.App;
+import sui.View;
+import sui.ui.*;
+
+/**
+    Minimal example of sui's **dynamic renderer**.
+
+    Build with `sui build --watch macos`: instead of generating static Swift for
+    this view, sui walks the Haxe tree that `body()` returns at *runtime* through
+    the C `ViewNode` bridge, and `DynamicView.swift` rebuilds SwiftUI from it
+    recursively. The Button exercises the action path — a SwiftUI tap invokes the
+    Haxe closure directly through the live tree, so the click is observable on
+    stdout (and mutates `taps`, proving the closure captured `this`).
+
+    This is the same runtime-dynamic mechanism a protocol renderer uses; see
+    rsx2ui's `renderers/sui` for a full A2UI renderer built on it.
+**/
+class DynamicHello extends App {
+    static function main() {}
+
+    var taps:Int = 0;
+
+    public function new() {
+        super();
+        appName = "DynamicHello";
+        bundleIdentifier = "com.sui.dynamichello";
+    }
+
+    override function body():View {
+        return new VStack(null, 16, [
+            new Text("sui — renderer dynamique")
+                .font(FontStyle.LargeTitle)
+                .padding(),
+            new Text("Le view tree Haxe est rendu à l'exécution via le pont ViewNode.")
+                .padding(),
+            new Button("Clique-moi", () -> {
+                taps++;
+                Sys.println('[dynamic-hello] action Haxe déclenchée (tap #$taps)');
+            }).padding(),
+        ]);
+    }
+}

--- a/examples/dynamic-hello/sui.json
+++ b/examples/dynamic-hello/sui.json
@@ -1,0 +1,5 @@
+{
+    "appName": "DynamicHello",
+    "bundleIdentifier": "com.sui.dynamichello",
+    "bundleIdPrefix": "com.sui"
+}

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -481,31 +481,39 @@ struct DynamicModal: View {
 /// lane) are draggable between them. Only the drop returns to the app, as the
 /// onDrop action with a {card, lane, index} context; the app moves the card and
 /// re-renders. lanes/cards/dropAction arrive as JSON on properties.
+private struct BoardLane: Identifiable { let id: String; let title: String }
+private struct BoardCard: Identifiable { let id: String; let label: String; let lane: String }
+
 struct DynamicBoard: View {
     let node: ViewNode
+    // Shared namespace so a card matched by id animates (FLIP) as it moves from
+    // one lane's stack to another's when the app re-renders after a drop.
+    @Namespace private var ns
 
     var body: some View {
-        let lanes = parseObjArray(node.property("lanes"))
-        let cards = parseObjArray(node.property("cards"))
+        let lanes = parseBoardLanes(node.property("lanes"))
+        let cards = parseBoardCards(node.property("cards"))
         let dropAction = node.property("dropAction")
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(alignment: .top, spacing: 12) {
-                ForEach(lanes.indices, id: \.self) { i in
-                    lane(lanes[i], cards: cards, dropAction: dropAction)
+                ForEach(lanes) { lane in
+                    laneView(lane, cards: cards.filter { $0.lane == lane.id }, dropAction: dropAction)
                 }
             }
             .padding(8)
         }
     }
 
-    private func lane(_ lane: [String: Any], cards: [[String: Any]], dropAction: String) -> some View {
-        let laneId = lane["id"] as? String ?? ""
-        let laneCards = cards.filter { ($0["lane"] as? String) == laneId }
-        return VStack(alignment: .leading, spacing: 8) {
-            Text((lane["title"] as? String ?? "").uppercased())
-                .font(.caption2).foregroundStyle(.secondary)
-            ForEach(laneCards.indices, id: \.self) { i in
-                card(laneCards[i])
+    private func laneView(_ lane: BoardLane, cards: [BoardCard], dropAction: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(lane.title.uppercased()).font(.caption2).foregroundStyle(.secondary)
+            ForEach(cards) { card in
+                Text(card.label)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.08)))
+                    .matchedGeometryEffect(id: card.id, in: ns)
+                    .draggable(card.id)
             }
             Spacer(minLength: 0)
         }
@@ -515,25 +523,25 @@ struct DynamicBoard: View {
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.primary.opacity(0.12)))
         .dropDestination(for: String.self) { items, _ in
             guard let cardId = items.first else { return false }
-            let extra: [String: Any] = ["card": cardId, "lane": laneId, "index": laneCards.count]
+            let extra: [String: Any] = ["card": cardId, "lane": lane.id, "index": cards.count]
             let json = (try? JSONSerialization.data(withJSONObject: extra))
                 .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
             viewnode_fire_action(dropAction, json)
             return true
         }
     }
-
-    private func card(_ card: [String: Any]) -> some View {
-        Text(card["label"] as? String ?? "")
-            .padding(8)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.08)))
-            .draggable(card["id"] as? String ?? "")
-    }
 }
 
 private func parseObjArray(_ json: String) -> [[String: Any]] {
     (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [[String: Any]] ?? []
+}
+private func parseBoardLanes(_ json: String) -> [BoardLane] {
+    parseObjArray(json).map { BoardLane(id: $0["id"] as? String ?? "", title: $0["title"] as? String ?? "") }
+}
+private func parseBoardCards(_ json: String) -> [BoardCard] {
+    parseObjArray(json).map {
+        BoardCard(id: $0["id"] as? String ?? "", label: $0["label"] as? String ?? "", lane: $0["lane"] as? String ?? "")
+    }
 }
 
 // MARK: - Canvas drawing
@@ -563,10 +571,10 @@ struct DynamicCanvas: View {
             let t = CGAffineTransform(a: sx, b: 0, c: 0, d: sy,
                                       tx: (size.width - vw * sx) / 2,
                                       ty: (size.height - vh * sy) / 2)
-            // The "primary" token resolves to the surface theme's primaryColor.
-            let primary = spec["primary"] as? String ?? ""
+            // Semantic colour tokens resolved from the surface theme.
+            let theme = spec["theme"] as? [String: Any] ?? [:]
             for op in (spec["ops"] as? [[String: Any]] ?? []) {
-                drawCanvasOp(op, &ctx, t, primary)
+                drawCanvasOp(op, &ctx, t, theme)
             }
         }
     }
@@ -579,14 +587,15 @@ private func cnum(_ v: Any?) -> CGFloat? {
 private func cf(_ op: [String: Any], _ k: String, _ d: CGFloat = 0) -> CGFloat { cnum(op[k]) ?? d }
 private func cscale(_ t: CGAffineTransform) -> CGFloat { sqrt(abs(t.a * t.d - t.b * t.c)) }
 
-// A colour is a hex "#RRGGBB" or a semantic theme token. `primary` resolves to
-// the surface theme's primaryColor (falling back to the system accent); the
-// neutral tokens stay as adaptive system colours so drawings track light/dark.
-private func canvasColor(_ op: [String: Any], _ key: String, _ primary: String) -> Color? {
+// A colour is a hex "#RRGGBB" or a semantic token. A token first resolves to a
+// surface-theme override (hex), then falls back to an adaptive system colour so
+// untethered drawings still track light/dark.
+private func canvasColor(_ op: [String: Any], _ key: String, _ theme: [String: Any]) -> Color? {
     guard let s = op[key] as? String, !s.isEmpty else { return nil }
     if s.hasPrefix("#") { return Color(suiHex: s) }
+    if let hex = theme[s] as? String, hex.hasPrefix("#") { return Color(suiHex: hex) }
     switch s {
-    case "primary":   return primary.hasPrefix("#") ? (Color(suiHex: primary) ?? .accentColor) : .accentColor
+    case "primary":   return .accentColor
     case "onPrimary": return .white
     case "surface":   return Color(white: 0.5).opacity(0.12)
     case "onSurface": return .primary
@@ -606,37 +615,37 @@ private func canvasStroke(_ op: [String: Any], _ t: CGAffineTransform) -> Stroke
     return StrokeStyle(lineWidth: cf(op, "strokeWidth", 1) * cscale(t), lineCap: cap)
 }
 
-private func paintCanvas(_ ctx: inout GraphicsContext, _ path: Path, _ op: [String: Any], _ t: CGAffineTransform, _ primary: String) {
+private func paintCanvas(_ ctx: inout GraphicsContext, _ path: Path, _ op: [String: Any], _ t: CGAffineTransform, _ theme: [String: Any]) {
     ctx.opacity = Double(cf(op, "opacity", 1))
-    if let fill = canvasColor(op, "fill", primary) { ctx.fill(path, with: .color(fill)) }
-    if let stroke = canvasColor(op, "stroke", primary) { ctx.stroke(path, with: .color(stroke), style: canvasStroke(op, t)) }
+    if let fill = canvasColor(op, "fill", theme) { ctx.fill(path, with: .color(fill)) }
+    if let stroke = canvasColor(op, "stroke", theme) { ctx.stroke(path, with: .color(stroke), style: canvasStroke(op, t)) }
     ctx.opacity = 1
 }
 
 // Coordinates are in viewBox space; each op's Path is built there then mapped to
 // screen with `t` (so lines stay crisp and arcs stay circular under affine).
-private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t: CGAffineTransform, _ primary: String) {
+private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t: CGAffineTransform, _ theme: [String: Any]) {
     switch op["op"] as? String {
     case "rect":
         let r = CGRect(x: cf(op, "x"), y: cf(op, "y"), width: cf(op, "w"), height: cf(op, "h"))
         let rx = cf(op, "rx")
-        paintCanvas(&ctx, (rx > 0 ? Path(roundedRect: r, cornerRadius: rx) : Path(r)).applying(t), op, t, primary)
+        paintCanvas(&ctx, (rx > 0 ? Path(roundedRect: r, cornerRadius: rx) : Path(r)).applying(t), op, t, theme)
 
     case "line":
         var p = Path()
         p.move(to: CGPoint(x: cf(op, "x1"), y: cf(op, "y1")))
         p.addLine(to: CGPoint(x: cf(op, "x2"), y: cf(op, "y2")))
-        paintCanvas(&ctx, p.applying(t), op, t, primary)
+        paintCanvas(&ctx, p.applying(t), op, t, theme)
 
     case "circle":
         let r = cf(op, "r")
         let rect = CGRect(x: cf(op, "cx") - r, y: cf(op, "cy") - r, width: 2 * r, height: 2 * r)
-        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, primary)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, theme)
 
     case "ellipse":
         let rx = cf(op, "rx"), ry = cf(op, "ry")
         let rect = CGRect(x: cf(op, "cx") - rx, y: cf(op, "cy") - ry, width: 2 * rx, height: 2 * ry)
-        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, primary)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, theme)
 
     case "arc":
         // A2UI: degrees, 0° at 3 o'clock, clockwise positive.
@@ -648,7 +657,7 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
                  startAngle: .degrees(cf(op, "start")), endAngle: .degrees(cf(op, "end")),
                  clockwise: false)
         if close { p.closeSubpath() }
-        paintCanvas(&ctx, p.applying(t), op, t, primary)
+        paintCanvas(&ctx, p.applying(t), op, t, theme)
 
     case "polyline":
         let pts = op["points"] as? [[Any]] ?? []
@@ -659,13 +668,13 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
             if i == 0 { p.move(to: CGPoint(x: x, y: y)) } else { p.addLine(to: CGPoint(x: x, y: y)) }
         }
         if op["closed"] as? Bool ?? false { p.closeSubpath() }
-        paintCanvas(&ctx, p.applying(t), op, t, primary)
+        paintCanvas(&ctx, p.applying(t), op, t, theme)
 
     case "text":
         let size = cf(op, "size", 12) * cscale(t)
         let weight: Font.Weight = cf(op, "weight", 400) >= 600 ? .bold : .regular
         var text = Text(op["text"] as? String ?? "").font(.system(size: size, weight: weight))
-        if let fill = canvasColor(op, "fill", primary) { text = text.foregroundColor(fill) }
+        if let fill = canvasColor(op, "fill", theme) { text = text.foregroundColor(fill) }
         let anchor: UnitPoint
         switch op["anchor"] as? String {
         case "middle": anchor = .center
@@ -682,7 +691,7 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
         if let rot = cnum(op["rotate"]) { gt = gt.rotated(by: rot * .pi / 180) }
         if let sc = cnum(op["scale"]) { gt = gt.scaledBy(x: sc, y: sc) }
         let child = gt.concatenating(t)
-        for sub in (op["ops"] as? [[String: Any]] ?? []) { drawCanvasOp(sub, &ctx, child, primary) }
+        for sub in (op["ops"] as? [[String: Any]] ?? []) { drawCanvasOp(sub, &ctx, child, theme) }
 
     default:
         break
@@ -724,10 +733,13 @@ struct HotReloadRootView: View {
             .id(root.id)
             .tint(accent)
             .onReceive(pollTimer) { _ in
-                if viewnode_poll() != 0 { reloadCount += 1 }
+                // Animate tree updates: with stable node identities, SwiftUI
+                // interpolates layout changes (a card moving lanes, a list
+                // reordering) instead of snapping.
+                if viewnode_poll() != 0 { withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { reloadCount += 1 } }
             }
             .onReceive(NotificationCenter.default.publisher(for: .viewTreeDidReload)) { _ in
-                reloadCount += 1
+                withAnimation { reloadCount += 1 }
             }
     }
 }

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -148,6 +148,16 @@ struct DynamicView: View {
         case "Canvas":
             DynamicCanvas(node: node)
 
+        case "Slider":
+            DynamicSlider(node: node)
+
+        case "Icon":
+            // A2UI icon name, interpreted as an SF Symbol (best effort). Icons
+            // carry no colour prop, so they take the theme accent (a brand
+            // element) — `.tint` only reaches interactive controls, not Images.
+            Image(systemName: node.property("name"))
+                .foregroundStyle(Color(suiHex: String(cString: viewnode_theme_accent())) ?? .primary)
+
         case "Image":
             let url = node.property("url")
             if !url.isEmpty, let u = URL(string: url) {
@@ -310,6 +320,32 @@ struct DynamicCheckBox: View {
             .onChange(of: on) { _, newValue in
                 viewnode_set_data(node.property("path"), newValue ? "true" : "false")
             }
+    }
+}
+
+/// An editable slider bound to a numeric data-model value (label + min/max).
+struct DynamicSlider: View {
+    let node: ViewNode
+    @State private var value: Double
+
+    init(node: ViewNode) {
+        self.node = node
+        _value = State(initialValue: Double(node.property("value")) ?? 0)
+    }
+
+    var body: some View {
+        let lo = Double(node.property("min")) ?? 0
+        let hi = Double(node.property("max")) ?? 100
+        let label = node.property("label")
+        return VStack(alignment: .leading, spacing: 2) {
+            if !label.isEmpty { Text(label).font(.caption).foregroundStyle(.secondary) }
+            Slider(value: $value, in: lo...Swift.max(hi, lo + 0.0001))
+                .onChange(of: value) { _, v in
+                    // Whole numbers write without a trailing ".0".
+                    let s = v == v.rounded() ? String(Int(v)) : String(format: "%.2f", v)
+                    viewnode_set_data(node.property("path"), s)
+                }
+        }
     }
 }
 

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -148,6 +148,9 @@ struct DynamicView: View {
         case "Canvas":
             DynamicCanvas(node: node)
 
+        case "Board":
+            DynamicBoard(node: node)
+
         case "Slider":
             DynamicSlider(node: node)
 
@@ -470,6 +473,67 @@ struct DynamicModal: View {
                 .padding()
             }
     }
+}
+
+// MARK: - Board (drag-and-drop)
+
+/// Board — the behaviour axis. Lanes are columns; cards (each tagged with a
+/// lane) are draggable between them. Only the drop returns to the app, as the
+/// onDrop action with a {card, lane, index} context; the app moves the card and
+/// re-renders. lanes/cards/dropAction arrive as JSON on properties.
+struct DynamicBoard: View {
+    let node: ViewNode
+
+    var body: some View {
+        let lanes = parseObjArray(node.property("lanes"))
+        let cards = parseObjArray(node.property("cards"))
+        let dropAction = node.property("dropAction")
+        return ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 12) {
+                ForEach(lanes.indices, id: \.self) { i in
+                    lane(lanes[i], cards: cards, dropAction: dropAction)
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    private func lane(_ lane: [String: Any], cards: [[String: Any]], dropAction: String) -> some View {
+        let laneId = lane["id"] as? String ?? ""
+        let laneCards = cards.filter { ($0["lane"] as? String) == laneId }
+        return VStack(alignment: .leading, spacing: 8) {
+            Text((lane["title"] as? String ?? "").uppercased())
+                .font(.caption2).foregroundStyle(.secondary)
+            ForEach(laneCards.indices, id: \.self) { i in
+                card(laneCards[i])
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(width: 190, alignment: .top)
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.primary.opacity(0.05)))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.primary.opacity(0.12)))
+        .dropDestination(for: String.self) { items, _ in
+            guard let cardId = items.first else { return false }
+            let extra: [String: Any] = ["card": cardId, "lane": laneId, "index": laneCards.count]
+            let json = (try? JSONSerialization.data(withJSONObject: extra))
+                .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+            viewnode_fire_action(dropAction, json)
+            return true
+        }
+    }
+
+    private func card(_ card: [String: Any]) -> some View {
+        Text(card["label"] as? String ?? "")
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.08)))
+            .draggable(card["id"] as? String ?? "")
+    }
+}
+
+private func parseObjArray(_ json: String) -> [[String: Any]] {
+    (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [[String: Any]] ?? []
 }
 
 // MARK: - Canvas drawing

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -12,7 +12,18 @@ import SwiftUI
 /// Opaque wrapper around a Haxe View pointer from the bridge.
 struct ViewNode: Identifiable {
     let pointer: UnsafeMutableRawPointer?
-    let id = UUID()
+
+    // Stable identity across rebuilds: the app tags each node with a "nodeId"
+    // property (e.g. its A2UI component id). Without it, fall back to the
+    // pointer — unstable across rebuilds, but such nodes carry no view state to
+    // preserve. A stable id lets SwiftUI diff the tree and keep input focus/text
+    // through a rebuild instead of tearing everything down.
+    var id: String {
+        let nid = property("nodeId")
+        if !nid.isEmpty { return nid }
+        if let p = pointer { return "ptr-\(UInt(bitPattern: p))" }
+        return "nil"
+    }
 
     var viewType: String {
         guard let ptr = pointer else { return "" }
@@ -127,13 +138,11 @@ struct DynamicView: View {
         case "Divider":
             Divider()
 
-        case "Toggle":
-            // Toggle requires state binding — simplified for now
-            Text("[Toggle: \(node.property("label"))]")
+        case "Toggle", "CheckBox":
+            DynamicCheckBox(node: node)
 
         case "TextField":
-            // TextField requires state binding — simplified for now
-            Text("[TextField: \(node.property("placeholder"))]")
+            DynamicTextField(node: node)
 
         case "Image":
             let name = node.property("systemName")
@@ -249,6 +258,48 @@ struct DynamicView: View {
     }
 }
 
+// MARK: - Editable inputs
+
+/// An editable text input. Its @State survives rebuilds (the node carries a
+/// stable id), so typing stays smooth; each edit writes back through the data
+/// bridge, and any bound mirror text re-renders on the next poll.
+struct DynamicTextField: View {
+    let node: ViewNode
+    @State private var text: String
+
+    init(node: ViewNode) {
+        self.node = node
+        _text = State(initialValue: node.property("value"))
+    }
+
+    var body: some View {
+        let label = node.property("label")
+        return TextField(label, text: $text)
+            .textFieldStyle(.roundedBorder)
+            .onChange(of: text) { _, newValue in
+                viewnode_set_data(node.property("path"), newValue)
+            }
+    }
+}
+
+/// An editable checkbox (rendered as a Toggle). Same stable-id contract.
+struct DynamicCheckBox: View {
+    let node: ViewNode
+    @State private var on: Bool
+
+    init(node: ViewNode) {
+        self.node = node
+        _on = State(initialValue: node.property("value") == "true")
+    }
+
+    var body: some View {
+        Toggle(node.property("label"), isOn: $on)
+            .onChange(of: on) { _, newValue in
+                viewnode_set_data(node.property("path"), newValue ? "true" : "false")
+            }
+    }
+}
+
 // MARK: - Hot Reload Root View
 
 /// The root view used in hot reload mode.
@@ -272,9 +323,14 @@ struct HotReloadRootView: View {
     init() { _ = _suiRuntimeBooted }
 
     var body: some View {
+        // Read reloadCount so a poll-driven bump re-evaluates body (re-reads the
+        // tree) — but do NOT use it as identity. The tree keeps a stable id, so
+        // SwiftUI diffs it and preserves input focus/text across rebuilds
+        // instead of tearing everything down every time.
+        let _ = reloadCount
         let root = ViewNode(pointer: viewnode_get_root())
         DynamicView(node: root)
-            .id(reloadCount) // force re-render on reload
+            .id(root.id)
             .onReceive(pollTimer) { _ in
                 if viewnode_poll() != 0 { reloadCount += 1 }
             }

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 /// Recursively renders a Haxe view tree at runtime.
 /// Used by `mui watch` for hot reload — the Swift host stays running
@@ -144,12 +145,24 @@ struct DynamicView: View {
         case "TextField":
             DynamicTextField(node: node)
 
+        case "Canvas":
+            DynamicCanvas(node: node)
+
         case "Image":
-            let name = node.property("systemName")
-            if !name.isEmpty {
-                Image(systemName: name)
+            let url = node.property("url")
+            if !url.isEmpty, let u = URL(string: url) {
+                AsyncImage(url: u) { img in
+                    img.resizable().scaledToFit()
+                } placeholder: {
+                    ProgressView()
+                }
             } else {
-                Image(node.property("name"))
+                let name = node.property("systemName")
+                if !name.isEmpty {
+                    Image(systemName: name)
+                } else {
+                    Image(node.property("name"))
+                }
             }
 
         case "ProgressView":
@@ -297,6 +310,155 @@ struct DynamicCheckBox: View {
             .onChange(of: on) { _, newValue in
                 viewnode_set_data(node.property("path"), newValue ? "true" : "false")
             }
+    }
+}
+
+// MARK: - Canvas drawing
+
+/// Interprets an A2UI Canvas spec — `{viewBox, ops, fit}`, delivered as JSON on
+/// the "canvas" property — into native SwiftUI drawing. One interpreter renders
+/// every Canvas-based component (gauges, sparklines, charts): the drawing logic
+/// lives once, server-side, and each op is replayed here through a GraphicsContext.
+struct DynamicCanvas: View {
+    let node: ViewNode
+
+    var body: some View {
+        let json = node.property("canvas")
+        let spec = (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [String: Any]
+        return Canvas { ctx, size in
+            guard let spec = spec,
+                  let vb = spec["viewBox"] as? [String: Any],
+                  let vw = cnum(vb["w"]), let vh = cnum(vb["h"]), vw > 0, vh > 0
+            else { return }
+            let sx: CGFloat, sy: CGFloat
+            switch spec["fit"] as? String {
+            case "stretch": sx = size.width / vw; sy = size.height / vh
+            case "cover":   let s = max(size.width / vw, size.height / vh); sx = s; sy = s
+            default:        let s = min(size.width / vw, size.height / vh); sx = s; sy = s // contain
+            }
+            // viewBox → allocated box: uniform (or stretch) scale, centered.
+            let t = CGAffineTransform(a: sx, b: 0, c: 0, d: sy,
+                                      tx: (size.width - vw * sx) / 2,
+                                      ty: (size.height - vh * sy) / 2)
+            for op in (spec["ops"] as? [[String: Any]] ?? []) {
+                drawCanvasOp(op, &ctx, t)
+            }
+        }
+    }
+}
+
+private func cnum(_ v: Any?) -> CGFloat? {
+    if let n = v as? NSNumber { return CGFloat(n.doubleValue) }
+    return nil
+}
+private func cf(_ op: [String: Any], _ k: String, _ d: CGFloat = 0) -> CGFloat { cnum(op[k]) ?? d }
+private func cscale(_ t: CGAffineTransform) -> CGFloat { sqrt(abs(t.a * t.d - t.b * t.c)) }
+
+// A colour is a hex "#RRGGBB" or a semantic theme token.
+private func canvasColor(_ op: [String: Any], _ key: String) -> Color? {
+    guard let s = op[key] as? String, !s.isEmpty else { return nil }
+    if s.hasPrefix("#") { return Color(suiHex: s) }
+    switch s {
+    case "primary":   return .accentColor
+    case "onPrimary": return .white
+    case "surface":   return Color(white: 0.5).opacity(0.12)
+    case "onSurface": return .primary
+    case "border":    return .gray.opacity(0.5)
+    case "muted":     return .secondary
+    default:          return .primary
+    }
+}
+
+private func canvasStroke(_ op: [String: Any], _ t: CGAffineTransform) -> StrokeStyle {
+    let cap: CGLineCap
+    switch op["cap"] as? String {
+    case "round":  cap = .round
+    case "square": cap = .square
+    default:       cap = .butt
+    }
+    return StrokeStyle(lineWidth: cf(op, "strokeWidth", 1) * cscale(t), lineCap: cap)
+}
+
+private func paintCanvas(_ ctx: inout GraphicsContext, _ path: Path, _ op: [String: Any], _ t: CGAffineTransform) {
+    ctx.opacity = Double(cf(op, "opacity", 1))
+    if let fill = canvasColor(op, "fill") { ctx.fill(path, with: .color(fill)) }
+    if let stroke = canvasColor(op, "stroke") { ctx.stroke(path, with: .color(stroke), style: canvasStroke(op, t)) }
+    ctx.opacity = 1
+}
+
+// Coordinates are in viewBox space; each op's Path is built there then mapped to
+// screen with `t` (so lines stay crisp and arcs stay circular under affine).
+private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t: CGAffineTransform) {
+    switch op["op"] as? String {
+    case "rect":
+        let r = CGRect(x: cf(op, "x"), y: cf(op, "y"), width: cf(op, "w"), height: cf(op, "h"))
+        let rx = cf(op, "rx")
+        paintCanvas(&ctx, (rx > 0 ? Path(roundedRect: r, cornerRadius: rx) : Path(r)).applying(t), op, t)
+
+    case "line":
+        var p = Path()
+        p.move(to: CGPoint(x: cf(op, "x1"), y: cf(op, "y1")))
+        p.addLine(to: CGPoint(x: cf(op, "x2"), y: cf(op, "y2")))
+        paintCanvas(&ctx, p.applying(t), op, t)
+
+    case "circle":
+        let r = cf(op, "r")
+        let rect = CGRect(x: cf(op, "cx") - r, y: cf(op, "cy") - r, width: 2 * r, height: 2 * r)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t)
+
+    case "ellipse":
+        let rx = cf(op, "rx"), ry = cf(op, "ry")
+        let rect = CGRect(x: cf(op, "cx") - rx, y: cf(op, "cy") - ry, width: 2 * rx, height: 2 * ry)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t)
+
+    case "arc":
+        // A2UI: degrees, 0° at 3 o'clock, clockwise positive.
+        let c = CGPoint(x: cf(op, "cx"), y: cf(op, "cy"))
+        let close = op["close"] as? Bool ?? false
+        var p = Path()
+        if close { p.move(to: c) }
+        p.addArc(center: c, radius: cf(op, "r"),
+                 startAngle: .degrees(cf(op, "start")), endAngle: .degrees(cf(op, "end")),
+                 clockwise: false)
+        if close { p.closeSubpath() }
+        paintCanvas(&ctx, p.applying(t), op, t)
+
+    case "polyline":
+        let pts = op["points"] as? [[Any]] ?? []
+        var p = Path()
+        for (i, pt) in pts.enumerated() {
+            let x = cnum(pt.first) ?? 0
+            let y = cnum(pt.count > 1 ? pt[1] : nil) ?? 0
+            if i == 0 { p.move(to: CGPoint(x: x, y: y)) } else { p.addLine(to: CGPoint(x: x, y: y)) }
+        }
+        if op["closed"] as? Bool ?? false { p.closeSubpath() }
+        paintCanvas(&ctx, p.applying(t), op, t)
+
+    case "text":
+        let size = cf(op, "size", 12) * cscale(t)
+        let weight: Font.Weight = cf(op, "weight", 400) >= 600 ? .bold : .regular
+        var text = Text(op["text"] as? String ?? "").font(.system(size: size, weight: weight))
+        if let fill = canvasColor(op, "fill") { text = text.foregroundColor(fill) }
+        let anchor: UnitPoint
+        switch op["anchor"] as? String {
+        case "middle": anchor = .center
+        case "end":    anchor = .trailing
+        default:       anchor = .leading
+        }
+        ctx.draw(text, at: CGPoint(x: cf(op, "x"), y: cf(op, "y")).applying(t), anchor: anchor)
+
+    case "group":
+        var gt = CGAffineTransform.identity
+        if let tr = op["translate"] as? [Any], tr.count >= 2 {
+            gt = gt.translatedBy(x: cnum(tr[0]) ?? 0, y: cnum(tr[1]) ?? 0)
+        }
+        if let rot = cnum(op["rotate"]) { gt = gt.rotated(by: rot * .pi / 180) }
+        if let sc = cnum(op["scale"]) { gt = gt.scaledBy(x: sc, y: sc) }
+        let child = gt.concatenating(t)
+        for sub in (op["ops"] as? [[String: Any]] ?? []) { drawCanvasOp(sub, &ctx, child) }
+
+    default:
+        break
     }
 }
 

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -151,6 +151,9 @@ struct DynamicView: View {
         case "Slider":
             DynamicSlider(node: node)
 
+        case "ChoicePicker":
+            DynamicPicker(node: node)
+
         case "Icon":
             // A2UI icon name, interpreted as an SF Symbol (best effort). Icons
             // carry no colour prop, so they take the theme accent (a brand
@@ -347,6 +350,72 @@ struct DynamicSlider: View {
                 }
         }
     }
+}
+
+/// A choice picker bound to an Array<String> of selected values. A single-select
+/// (mutuallyExclusive) surface renders as a native Picker; multipleSelection as
+/// a checkable Menu. Edits write the new array back through the data bridge.
+struct DynamicPicker: View {
+    let node: ViewNode
+    @State private var selected: [String]
+
+    init(node: ViewNode) {
+        self.node = node
+        _selected = State(initialValue: parseStringArray(node.property("selected")))
+    }
+
+    var body: some View {
+        let options = parsePickerOptions(node.property("options"))
+        let label = node.property("label")
+        return Group {
+            if node.property("variant") == "multipleSelection" {
+                Menu {
+                    ForEach(options, id: \.value) { opt in
+                        Button { toggle(opt.value) } label: {
+                            Label(opt.label, systemImage: selected.contains(opt.value) ? "checkmark" : "")
+                        }
+                    }
+                } label: {
+                    let names = options.filter { selected.contains($0.value) }.map(\.label)
+                    Text(names.isEmpty ? label : names.joined(separator: ", "))
+                }
+            } else {
+                Picker(label, selection: singleSelection) {
+                    ForEach(options, id: \.value) { opt in
+                        Text(opt.label).tag(opt.value)
+                    }
+                }
+            }
+        }
+    }
+
+    private var singleSelection: Binding<String> {
+        Binding(get: { selected.first ?? "" }, set: { selected = [$0]; write() })
+    }
+
+    private func toggle(_ value: String) {
+        if let i = selected.firstIndex(of: value) { selected.remove(at: i) } else { selected.append(value) }
+        write()
+    }
+
+    private func write() {
+        let json = (try? JSONSerialization.data(withJSONObject: selected))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+        viewnode_set_data(node.property("path"), json)
+    }
+}
+
+private func parsePickerOptions(_ json: String) -> [(label: String, value: String)] {
+    guard let arr = (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [[String: Any]] else { return [] }
+    return arr.map { (
+        label: ($0["label"] as? String) ?? ($0["value"] as? String) ?? "",
+        value: ($0["value"] as? String) ?? ""
+    ) }
+}
+
+private func parseStringArray(_ json: String) -> [String] {
+    guard let arr = (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [Any] else { return [] }
+    return arr.compactMap { $0 as? String }
 }
 
 // MARK: - Canvas drawing

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -495,8 +495,11 @@ struct HotReloadRootView: View {
         // instead of tearing everything down every time.
         let _ = reloadCount
         let root = ViewNode(pointer: viewnode_get_root())
+        // Tint native controls with the theme accent (surface primaryColor).
+        let accent = Color(suiHex: String(cString: viewnode_theme_accent()))
         DynamicView(node: root)
             .id(root.id)
+            .tint(accent)
             .onReceive(pollTimer) { _ in
                 if viewnode_poll() != 0 { reloadCount += 1 }
             }

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -48,6 +48,11 @@ struct ViewNode: Identifiable {
         return viewnode_get_button_action_id(ptr)
     }
 
+    func invokeAction() {
+        guard let ptr = pointer else { return }
+        viewnode_invoke_action(ptr)
+    }
+
     func property(_ key: String) -> String {
         guard let ptr = pointer else { return "" }
         return String(cString: viewnode_get_property(ptr, key))
@@ -66,6 +71,11 @@ struct ViewNode: Identifiable {
     func modifierFloat(at index: Int, param: Int = 0) -> Double {
         guard let ptr = pointer else { return 0 }
         return viewnode_modifier_float(ptr, Int32(index), Int32(param))
+    }
+
+    func modifierString(at index: Int, param: Int = 0) -> String {
+        guard let ptr = pointer else { return "" }
+        return String(cString: viewnode_modifier_string(ptr, Int32(index), Int32(param)))
     }
 }
 
@@ -107,11 +117,8 @@ struct DynamicView: View {
             Text(node.textContent)
 
         case "Button":
-            let actionId = node.buttonActionId
             Button(node.buttonLabel) {
-                if actionId >= 0 {
-                    haxe_bridge_invoke_action(actionId)
-                }
+                node.invokeAction()
             }
 
         case "Spacer":
@@ -173,15 +180,29 @@ struct DynamicView: View {
             switch modType {
             case "Padding":
                 let value = node.modifierFloat(at: i)
-                result = AnyView(result.padding(value > 0 ? CGFloat(value) : nil))
+                result = value > 0 ? AnyView(result.padding(CGFloat(value))) : AnyView(result.padding())
 
             case "PaddingDefault":
                 result = AnyView(result.padding())
 
             case "Font":
-                let styleStr = node.modifierType(at: i)
-                // Simplified — map common font styles
-                result = AnyView(result.font(.body))
+                // sui's Font(FontStyle) — param 0 is the FontStyle enum name.
+                let font: Font
+                switch node.modifierString(at: i, param: 0) {
+                case "LargeTitle":   font = .largeTitle
+                case "Title":        font = .title
+                case "Title2":       font = .title2
+                case "Title3":       font = .title3
+                case "Headline":     font = .headline
+                case "Subheadline":  font = .subheadline
+                case "Body":         font = .body
+                case "Callout":      font = .callout
+                case "Footnote":     font = .footnote
+                case "Caption":      font = .caption
+                case "Caption2":     font = .caption2
+                default:             font = .body
+                }
+                result = AnyView(result.font(font))
 
             case "Bold":
                 result = AnyView(result.bold())
@@ -232,13 +253,31 @@ struct DynamicView: View {
 
 /// The root view used in hot reload mode.
 /// Watches for .cppia file changes and triggers re-render.
+// Boots the hxcpp runtime + registers the app exactly once, before the first
+// view-tree traversal. A global `let` is initialised lazily and thread-safely
+// on first access (Swift dispatch_once semantics), so referencing it at the
+// top of `body` guarantees `viewnode_get_root()` sees an initialised runtime.
+private let _suiRuntimeBooted: Bool = {
+    viewnode_boot()
+    return true
+}()
+
 struct HotReloadRootView: View {
     @State private var reloadCount = 0
+
+    // Pump the app's poll delegate on the main thread (drains the WS queue).
+    private let pollTimer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    // Boot the runtime before the first body evaluation reads the view tree.
+    init() { _ = _suiRuntimeBooted }
 
     var body: some View {
         let root = ViewNode(pointer: viewnode_get_root())
         DynamicView(node: root)
             .id(reloadCount) // force re-render on reload
+            .onReceive(pollTimer) { _ in
+                if viewnode_poll() != 0 { reloadCount += 1 }
+            }
             .onReceive(NotificationCenter.default.publisher(for: .viewTreeDidReload)) { _ in
                 reloadCount += 1
             }

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -154,6 +154,12 @@ struct DynamicView: View {
         case "ChoicePicker":
             DynamicPicker(node: node)
 
+        case "Tabs":
+            DynamicTabs(node: node)
+
+        case "Modal":
+            DynamicModal(node: node)
+
         case "Icon":
             // A2UI icon name, interpreted as an SF Symbol (best effort). Icons
             // carry no colour prop, so they take the theme accent (a brand
@@ -416,6 +422,54 @@ private func parsePickerOptions(_ json: String) -> [(label: String, value: Strin
 private func parseStringArray(_ json: String) -> [String] {
     guard let arr = (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [Any] else { return [] }
     return arr.compactMap { $0 as? String }
+}
+
+/// Tabs — the tab contents are this node's children; the titles are a parallel
+/// JSON array on the "titles" property.
+struct DynamicTabs: View {
+    let node: ViewNode
+    @State private var selection = 0
+
+    var body: some View {
+        let titles = parseStringArray(node.property("titles"))
+        let children = node.children
+        return TabView(selection: $selection) {
+            ForEach(Array(children.enumerated()), id: \.offset) { idx, child in
+                DynamicView(node: child)
+                    .tabItem { Text(idx < titles.count ? titles[idx] : "Tab \(idx + 1)") }
+                    .tag(idx)
+            }
+        }
+    }
+}
+
+/// Modal — child[0] is the trigger, child[1] the content. Tapping the trigger
+/// presents the content in a sheet.
+struct DynamicModal: View {
+    let node: ViewNode
+    @State private var presented = false
+
+    var body: some View {
+        let children = node.children
+        let trigger = children.first ?? ViewNode(pointer: nil)
+        let content = children.count > 1 ? children[1] : ViewNode(pointer: nil)
+        // The trigger renders as-is; a clear overlay on top captures the tap and
+        // opens the modal (A2UI: the trigger opens it). This avoids nesting the
+        // trigger — often itself a Button — inside another control.
+        return DynamicView(node: trigger)
+            .overlay(
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { presented = true }
+            )
+            .sheet(isPresented: $presented) {
+                VStack(spacing: 16) {
+                    DynamicView(node: content)
+                    Button("Close") { presented = false }
+                }
+                .padding()
+            }
+    }
 }
 
 // MARK: - Canvas drawing

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Foundation
+import AVKit
 
 /// Recursively renders a Haxe view tree at runtime.
 /// Used by `mui watch` for hot reload — the Swift host stays running
@@ -169,6 +170,9 @@ struct DynamicView: View {
             // element) — `.tint` only reaches interactive controls, not Images.
             Image(systemName: node.property("name"))
                 .foregroundStyle(Color(suiHex: String(cString: viewnode_theme_accent())) ?? .primary)
+
+        case "Video":
+            DynamicVideo(node: node)
 
         case "Image":
             let url = node.property("url")
@@ -472,6 +476,30 @@ struct DynamicModal: View {
                 }
                 .padding()
             }
+    }
+}
+
+/// Video — an AVKit player over the A2UI url. The player is held in @State so
+/// playback survives re-renders (the node keeps a stable id).
+struct DynamicVideo: View {
+    let node: ViewNode
+    @State private var player: AVPlayer?
+
+    init(node: ViewNode) {
+        self.node = node
+        if let u = URL(string: node.property("url")) {
+            _player = State(initialValue: AVPlayer(url: u))
+        }
+    }
+
+    var body: some View {
+        Group {
+            if let player = player {
+                VideoPlayer(player: player).frame(minHeight: 220)
+            } else {
+                Text("Vidéo indisponible").foregroundStyle(.secondary)
+            }
+        }
     }
 }
 

--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -340,8 +340,10 @@ struct DynamicCanvas: View {
             let t = CGAffineTransform(a: sx, b: 0, c: 0, d: sy,
                                       tx: (size.width - vw * sx) / 2,
                                       ty: (size.height - vh * sy) / 2)
+            // The "primary" token resolves to the surface theme's primaryColor.
+            let primary = spec["primary"] as? String ?? ""
             for op in (spec["ops"] as? [[String: Any]] ?? []) {
-                drawCanvasOp(op, &ctx, t)
+                drawCanvasOp(op, &ctx, t, primary)
             }
         }
     }
@@ -354,12 +356,14 @@ private func cnum(_ v: Any?) -> CGFloat? {
 private func cf(_ op: [String: Any], _ k: String, _ d: CGFloat = 0) -> CGFloat { cnum(op[k]) ?? d }
 private func cscale(_ t: CGAffineTransform) -> CGFloat { sqrt(abs(t.a * t.d - t.b * t.c)) }
 
-// A colour is a hex "#RRGGBB" or a semantic theme token.
-private func canvasColor(_ op: [String: Any], _ key: String) -> Color? {
+// A colour is a hex "#RRGGBB" or a semantic theme token. `primary` resolves to
+// the surface theme's primaryColor (falling back to the system accent); the
+// neutral tokens stay as adaptive system colours so drawings track light/dark.
+private func canvasColor(_ op: [String: Any], _ key: String, _ primary: String) -> Color? {
     guard let s = op[key] as? String, !s.isEmpty else { return nil }
     if s.hasPrefix("#") { return Color(suiHex: s) }
     switch s {
-    case "primary":   return .accentColor
+    case "primary":   return primary.hasPrefix("#") ? (Color(suiHex: primary) ?? .accentColor) : .accentColor
     case "onPrimary": return .white
     case "surface":   return Color(white: 0.5).opacity(0.12)
     case "onSurface": return .primary
@@ -379,37 +383,37 @@ private func canvasStroke(_ op: [String: Any], _ t: CGAffineTransform) -> Stroke
     return StrokeStyle(lineWidth: cf(op, "strokeWidth", 1) * cscale(t), lineCap: cap)
 }
 
-private func paintCanvas(_ ctx: inout GraphicsContext, _ path: Path, _ op: [String: Any], _ t: CGAffineTransform) {
+private func paintCanvas(_ ctx: inout GraphicsContext, _ path: Path, _ op: [String: Any], _ t: CGAffineTransform, _ primary: String) {
     ctx.opacity = Double(cf(op, "opacity", 1))
-    if let fill = canvasColor(op, "fill") { ctx.fill(path, with: .color(fill)) }
-    if let stroke = canvasColor(op, "stroke") { ctx.stroke(path, with: .color(stroke), style: canvasStroke(op, t)) }
+    if let fill = canvasColor(op, "fill", primary) { ctx.fill(path, with: .color(fill)) }
+    if let stroke = canvasColor(op, "stroke", primary) { ctx.stroke(path, with: .color(stroke), style: canvasStroke(op, t)) }
     ctx.opacity = 1
 }
 
 // Coordinates are in viewBox space; each op's Path is built there then mapped to
 // screen with `t` (so lines stay crisp and arcs stay circular under affine).
-private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t: CGAffineTransform) {
+private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t: CGAffineTransform, _ primary: String) {
     switch op["op"] as? String {
     case "rect":
         let r = CGRect(x: cf(op, "x"), y: cf(op, "y"), width: cf(op, "w"), height: cf(op, "h"))
         let rx = cf(op, "rx")
-        paintCanvas(&ctx, (rx > 0 ? Path(roundedRect: r, cornerRadius: rx) : Path(r)).applying(t), op, t)
+        paintCanvas(&ctx, (rx > 0 ? Path(roundedRect: r, cornerRadius: rx) : Path(r)).applying(t), op, t, primary)
 
     case "line":
         var p = Path()
         p.move(to: CGPoint(x: cf(op, "x1"), y: cf(op, "y1")))
         p.addLine(to: CGPoint(x: cf(op, "x2"), y: cf(op, "y2")))
-        paintCanvas(&ctx, p.applying(t), op, t)
+        paintCanvas(&ctx, p.applying(t), op, t, primary)
 
     case "circle":
         let r = cf(op, "r")
         let rect = CGRect(x: cf(op, "cx") - r, y: cf(op, "cy") - r, width: 2 * r, height: 2 * r)
-        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, primary)
 
     case "ellipse":
         let rx = cf(op, "rx"), ry = cf(op, "ry")
         let rect = CGRect(x: cf(op, "cx") - rx, y: cf(op, "cy") - ry, width: 2 * rx, height: 2 * ry)
-        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t)
+        paintCanvas(&ctx, Path(ellipseIn: rect).applying(t), op, t, primary)
 
     case "arc":
         // A2UI: degrees, 0° at 3 o'clock, clockwise positive.
@@ -421,7 +425,7 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
                  startAngle: .degrees(cf(op, "start")), endAngle: .degrees(cf(op, "end")),
                  clockwise: false)
         if close { p.closeSubpath() }
-        paintCanvas(&ctx, p.applying(t), op, t)
+        paintCanvas(&ctx, p.applying(t), op, t, primary)
 
     case "polyline":
         let pts = op["points"] as? [[Any]] ?? []
@@ -432,13 +436,13 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
             if i == 0 { p.move(to: CGPoint(x: x, y: y)) } else { p.addLine(to: CGPoint(x: x, y: y)) }
         }
         if op["closed"] as? Bool ?? false { p.closeSubpath() }
-        paintCanvas(&ctx, p.applying(t), op, t)
+        paintCanvas(&ctx, p.applying(t), op, t, primary)
 
     case "text":
         let size = cf(op, "size", 12) * cscale(t)
         let weight: Font.Weight = cf(op, "weight", 400) >= 600 ? .bold : .regular
         var text = Text(op["text"] as? String ?? "").font(.system(size: size, weight: weight))
-        if let fill = canvasColor(op, "fill") { text = text.foregroundColor(fill) }
+        if let fill = canvasColor(op, "fill", primary) { text = text.foregroundColor(fill) }
         let anchor: UnitPoint
         switch op["anchor"] as? String {
         case "middle": anchor = .center
@@ -455,7 +459,7 @@ private func drawCanvasOp(_ op: [String: Any], _ ctx: inout GraphicsContext, _ t
         if let rot = cnum(op["rotate"]) { gt = gt.rotated(by: rot * .pi / 180) }
         if let sc = cnum(op["scale"]) { gt = gt.scaledBy(x: sc, y: sc) }
         let child = gt.concatenating(t)
-        for sub in (op["ops"] as? [[String: Any]] ?? []) { drawCanvasOp(sub, &ctx, child) }
+        for sub in (op["ops"] as? [[String: Any]] ?? []) { drawCanvasOp(sub, &ctx, child, primary) }
 
     default:
         break

--- a/runtime/ViewNodeBridgeC.cpp
+++ b/runtime/ViewNodeBridgeC.cpp
@@ -3,241 +3,232 @@
  * Called by native dynamic renderers (SwiftUI, Compose, WinUI)
  * to walk the Haxe view tree at runtime.
  *
- * Each function calls into Haxe via hxcpp reflection.
+ * Every function calls the sui.runtime.ViewNodeBridge statics through their
+ * direct hxcpp symbols — the same style the static bridge uses for
+ * Callbacks_obj::run. ViewNodeBridge is @:keep, so all its methods are present
+ * in the generated header regardless of DCE. (An earlier draft used Type_obj
+ * reflection, but Haxe's Type has no callStatic and DCE strips the rest, so the
+ * direct-symbol path is both correct and more robust.)
+ *
+ * Nodes cross the boundary as opaque void* — the raw hx::Object* behind a
+ * ::sui::View. GC note: each entry registers the stack top so allocations made
+ * while building strings stay reachable; returned strings and pointers must be
+ * copied by the caller before the next GC.
  */
 
 #include <hxcpp.h>
+#include <sui/View.h>
+#include <sui/runtime/ViewNodeBridge.h>
+#include <sui/state/Callbacks.h>
 
-// Forward declare the Haxe ViewNodeBridge class
-// These will be resolved at link time from the hxcpp static library.
+// hxcpp's library entry (hx::Init, in StdLibs.o) references the generated app
+// main (___hxcpp_lib_main, from __main__.o). That object is left out of the
+// static lib because its C main() would clash with the Swift @main entry — and
+// we never call hx::Init anyway: the app is driven through viewnode_boot →
+// hx::Boot → ViewNodeBridge. Provide a weak stub so the otherwise-dead
+// reference resolves; a real definition, if ever linked, takes precedence.
+extern "C" __attribute__((weak)) int __hxcpp_lib_main() { return 0; }
+
+// Wrap an opaque node pointer back into a typed ::sui::View. Null-safe: a null
+// pointer yields a null View, which every ViewNodeBridge method tolerates.
+static inline ::sui::View _asView(void* node) {
+    return ::sui::View((::sui::View_obj*)node);
+}
 
 extern "C" {
+
+// --- Action dispatch ---
+
+// Invoke a registered action closure by id. Mirrors the static bridge's
+// dispatch: both route through the sui.state.Callbacks store, so a Button
+// built at runtime via body() fires the same closure it registered with
+// Callbacks.reg().
+void haxe_bridge_invoke_action(int32_t actionId) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    try {
+        ::sui::state::Callbacks_obj::run(actionId);
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+}
 
 // --- View tree lifecycle ---
 
 // Rebuild the view tree (call App.body())
 void viewnode_rebuild(void) {
-    hx::SetTopOfStack(nullptr, true);
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
     try {
-        ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("rebuild"),
-            ::cpp::ObjectArray<Dynamic>(0, 0)
-        );
+        ::sui::runtime::ViewNodeBridge_obj::rebuild();
     } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
+    hx::SetTopOfStack((int*)0, false);
 }
 
-// --- Node accessors (node passed as opaque hxcpp Dynamic) ---
-
-// Get view type string. Caller must copy the result.
-const char* viewnode_get_type(void* node) {
-    hx::SetTopOfStack(nullptr, true);
-    const char* result = "";
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getViewType"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<String>().__CStr();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get number of children
-int32_t viewnode_child_count(void* node) {
-    hx::SetTopOfStack(nullptr, true);
+// Pump the poll delegate on the calling thread; returns 1 if the tree changed.
+int32_t viewnode_poll(void) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
     int32_t result = 0;
     try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getChildCount"),
-            args
-        );
-        result = (int)ret;
+        result = ::sui::runtime::ViewNodeBridge_obj::poll() ? 1 : 0;
     } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get child at index (returns opaque pointer)
-void* viewnode_get_child(void* node, int32_t index) {
-    hx::SetTopOfStack(nullptr, true);
-    void* result = nullptr;
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
-        args[0] = hxNode;
-        args[1] = (int)index;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getChild"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<hx::Object*>();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get text content
-const char* viewnode_get_text(void* node) {
-    hx::SetTopOfStack(nullptr, true);
-    const char* result = "";
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getTextContent"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<String>().__CStr();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get button label
-const char* viewnode_get_button_label(void* node) {
-    hx::SetTopOfStack(nullptr, true);
-    const char* result = "";
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getButtonLabel"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<String>().__CStr();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get button action ID
-int32_t viewnode_get_button_action_id(void* node) {
-    hx::SetTopOfStack(nullptr, true);
-    int32_t result = -1;
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getButtonActionId"),
-            args
-        );
-        result = (int)ret;
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get string property
-const char* viewnode_get_property(void* node, const char* key) {
-    hx::SetTopOfStack(nullptr, true);
-    const char* result = "";
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
-        args[0] = hxNode;
-        args[1] = ::String(key);
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getStringProperty"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<String>().__CStr();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get modifier count
-int32_t viewnode_modifier_count(void* node) {
-    hx::SetTopOfStack(nullptr, true);
-    int32_t result = 0;
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(1, 1);
-        args[0] = hxNode;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getModifierCount"),
-            args
-        );
-        result = (int)ret;
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get modifier type name at index
-const char* viewnode_modifier_type(void* node, int32_t index) {
-    hx::SetTopOfStack(nullptr, true);
-    const char* result = "";
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(2, 2);
-        args[0] = hxNode;
-        args[1] = (int)index;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getModifierType"),
-            args
-        );
-        if (ret != null()) result = ret.val_cast<String>().__CStr();
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
-    return result;
-}
-
-// Get modifier float parameter
-double viewnode_modifier_float(void* node, int32_t index, int32_t paramIndex) {
-    hx::SetTopOfStack(nullptr, true);
-    double result = 0.0;
-    try {
-        Dynamic hxNode = (hx::Object*)node;
-        auto args = ::cpp::ObjectArray<Dynamic>(3, 3);
-        args[0] = hxNode;
-        args[1] = (int)index;
-        args[2] = (int)paramIndex;
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getModifierFloat"),
-            args
-        );
-        result = (double)ret;
-    } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
+    hx::SetTopOfStack((int*)0, false);
     return result;
 }
 
 // Get root view node (returns opaque pointer)
 void* viewnode_get_root(void) {
-    hx::SetTopOfStack(nullptr, true);
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
     void* result = nullptr;
     try {
-        Dynamic ret = ::Type_obj::callStatic(
-            ::Type_obj::resolveClass(HX_CSTRING("sui.runtime.ViewNodeBridge")),
-            HX_CSTRING("getRoot"),
-            ::cpp::ObjectArray<Dynamic>(0, 0)
-        );
-        if (ret != null()) result = ret.val_cast<hx::Object*>();
+        ::sui::View root = ::sui::runtime::ViewNodeBridge_obj::getRoot();
+        result = root.GetPtr();
     } catch (...) {}
-    hx::SetTopOfStack(nullptr, false);
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+// --- Node accessors ---
+
+const char* viewnode_get_type(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getViewType(_asView(node)).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+int32_t viewnode_child_count(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    int32_t result = 0;
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getChildCount(_asView(node));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+void* viewnode_get_child(void* node, int32_t index) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    void* result = nullptr;
+    try {
+        ::sui::View child = ::sui::runtime::ViewNodeBridge_obj::getChild(_asView(node), index);
+        result = child.GetPtr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+// --- Properties ---
+
+const char* viewnode_get_property(void* node, const char* key) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getStringProperty(_asView(node), ::String(key)).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+// --- Text ---
+
+const char* viewnode_get_text(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getTextContent(_asView(node)).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+// --- Button ---
+
+const char* viewnode_get_button_label(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getButtonLabel(_asView(node)).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+int32_t viewnode_get_button_action_id(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    int32_t result = -1;
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getButtonActionId(_asView(node));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+// Invoke a Button node's action closure directly — the dynamic renderer holds
+// the live tree, so the closure on the node is GC-reachable and safe to call.
+void viewnode_invoke_action(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    try {
+        ::sui::runtime::ViewNodeBridge_obj::invokeButtonAction(_asView(node));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+}
+
+// --- Modifiers ---
+
+int32_t viewnode_modifier_count(void* node) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    int32_t result = 0;
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getModifierCount(_asView(node));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+const char* viewnode_modifier_type(void* node, int32_t index) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getModifierType(_asView(node), index).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+double viewnode_modifier_float(void* node, int32_t index, int32_t paramIndex) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    double result = 0.0;
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getModifierFloat(_asView(node), index, paramIndex);
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
+const char* viewnode_modifier_string(void* node, int32_t index, int32_t paramIndex) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getModifierString(_asView(node), index, paramIndex).__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
     return result;
 }
 

--- a/runtime/ViewNodeBridgeC.cpp
+++ b/runtime/ViewNodeBridgeC.cpp
@@ -86,6 +86,18 @@ void viewnode_set_data(const char* path, const char* value) {
     hx::SetTopOfStack((int*)0, false);
 }
 
+// The theme accent (primaryColor hex) to tint native controls with.
+const char* viewnode_theme_accent(void) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    const char* result = "";
+    try {
+        result = ::sui::runtime::ViewNodeBridge_obj::getAccent().__CStr();
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+    return result;
+}
+
 // Get root view node (returns opaque pointer)
 void* viewnode_get_root(void) {
     int dummy = 0;

--- a/runtime/ViewNodeBridgeC.cpp
+++ b/runtime/ViewNodeBridgeC.cpp
@@ -98,6 +98,16 @@ const char* viewnode_theme_accent(void) {
     return result;
 }
 
+// Fire a named action with a JSON extra-context.
+void viewnode_fire_action(const char* name, const char* extraJson) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    try {
+        ::sui::runtime::ViewNodeBridge_obj::fireAction(::String(name), ::String(extraJson));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+}
+
 // Get root view node (returns opaque pointer)
 void* viewnode_get_root(void) {
     int dummy = 0;

--- a/runtime/ViewNodeBridgeC.cpp
+++ b/runtime/ViewNodeBridgeC.cpp
@@ -76,6 +76,16 @@ int32_t viewnode_poll(void) {
     return result;
 }
 
+// A native input changed: write value at data-model path back into the app.
+void viewnode_set_data(const char* path, const char* value) {
+    int dummy = 0;
+    hx::SetTopOfStack(&dummy, true);
+    try {
+        ::sui::runtime::ViewNodeBridge_obj::setData(::String(path), ::String(value));
+    } catch (...) {}
+    hx::SetTopOfStack((int*)0, false);
+}
+
 // Get root view node (returns opaque pointer)
 void* viewnode_get_root(void) {
     int dummy = 0;

--- a/runtime/ViewNodeBridgeC.h
+++ b/runtime/ViewNodeBridgeC.h
@@ -7,9 +7,25 @@
 extern "C" {
 #endif
 
+// --- Runtime bootstrap (dynamic renderer / hot reload) ---
+// Boots the hxcpp runtime, instantiates the app, and registers it with
+// ViewNodeBridge so the view tree can be traversed. The hxcpp boot runs once;
+// subsequent calls just rebuild from the (re)loaded app. Implemented by the
+// macro-generated SuiBootC.cpp, which alone knows the concrete app class.
+void viewnode_boot(void);
+
 // --- View tree lifecycle ---
 void viewnode_rebuild(void);
 void* viewnode_get_root(void);
+// Pump the app's poll delegate (e.g. drain a WebSocket queue) on the calling
+// thread; returns non-zero if the view tree changed and should be re-rendered.
+int32_t viewnode_poll(void);
+
+// --- Action dispatch (dynamic renderer) ---
+// Invoke a registered action closure by its compile-time id. Routes to the
+// same sui.state.Callbacks store the static bridge uses, so buttons built at
+// runtime via body() dispatch identically.
+void haxe_bridge_invoke_action(int32_t actionId);
 
 // --- Node accessors ---
 const char* viewnode_get_type(void* node);
@@ -25,11 +41,14 @@ const char* viewnode_get_text(void* node);
 // --- Button ---
 const char* viewnode_get_button_label(void* node);
 int32_t viewnode_get_button_action_id(void* node);
+// Invoke a Button node's action closure directly (dynamic renderer path).
+void viewnode_invoke_action(void* node);
 
 // --- Modifiers ---
 int32_t viewnode_modifier_count(void* node);
 const char* viewnode_modifier_type(void* node, int32_t index);
 double viewnode_modifier_float(void* node, int32_t index, int32_t paramIndex);
+const char* viewnode_modifier_string(void* node, int32_t index, int32_t paramIndex);
 
 #ifdef __cplusplus
 }

--- a/runtime/ViewNodeBridgeC.h
+++ b/runtime/ViewNodeBridgeC.h
@@ -21,6 +21,9 @@ void* viewnode_get_root(void);
 // thread; returns non-zero if the view tree changed and should be re-rendered.
 int32_t viewnode_poll(void);
 
+// A native input changed: write `value` at data-model `path` back into the app.
+void viewnode_set_data(const char* path, const char* value);
+
 // --- Action dispatch (dynamic renderer) ---
 // Invoke a registered action closure by its compile-time id. Routes to the
 // same sui.state.Callbacks store the static bridge uses, so buttons built at

--- a/runtime/ViewNodeBridgeC.h
+++ b/runtime/ViewNodeBridgeC.h
@@ -24,6 +24,9 @@ int32_t viewnode_poll(void);
 // A native input changed: write `value` at data-model `path` back into the app.
 void viewnode_set_data(const char* path, const char* value);
 
+// The theme accent (primaryColor hex) to tint native controls with ("" = default).
+const char* viewnode_theme_accent(void);
+
 // --- Action dispatch (dynamic renderer) ---
 // Invoke a registered action closure by its compile-time id. Routes to the
 // same sui.state.Callbacks store the static bridge uses, so buttons built at

--- a/runtime/ViewNodeBridgeC.h
+++ b/runtime/ViewNodeBridgeC.h
@@ -27,6 +27,9 @@ void viewnode_set_data(const char* path, const char* value);
 // The theme accent (primaryColor hex) to tint native controls with ("" = default).
 const char* viewnode_theme_accent(void);
 
+// Fire a named action with a JSON extra-context (e.g. a Board drop's payload).
+void viewnode_fire_action(const char* name, const char* extraJson);
+
 // --- Action dispatch (dynamic renderer) ---
 // Invoke a registered action closure by its compile-time id. Routes to the
 // same sui.state.Callbacks store the static bridge uses, so buttons built at

--- a/src/sui/macros/SwiftGenerator.hx
+++ b/src/sui/macros/SwiftGenerator.hx
@@ -24,6 +24,15 @@ class SwiftGenerator {
     /** Hook into the Haxe compiler. Called via --macro in build.hxml. **/
     public static function register() {
         #if macro
+        // Dynamic renderer (hot reload): the native host reaches ViewNodeBridge
+        // and the Callbacks store only through the generated C bridge — via
+        // reflection and direct C++ symbols — never from Haxe. Nothing imports
+        // them, so force the modules into the compilation (getModule) and past
+        // DCE (both classes are @:keep) so their C++ symbols exist to link.
+        if (Context.defined("sui_hot_reload")) {
+            Context.getModule("sui.runtime.ViewNodeBridge");
+            Context.getModule("sui.state.Callbacks");
+        }
         var outputDir = Context.defined("swift-output") ? Context.definedValue("swift-output") : "build/swift";
 
         Context.onGenerate(function(types:Array<haxe.macro.Type>) {
@@ -138,6 +147,13 @@ class SwiftGenerator {
     // ── Main generation ─────────────────────────────────────────────
 
     static function generateSwift(cls:haxe.macro.Type.ClassType, outputDir:String, ?modelTypes:Map<String, haxe.macro.Type.ClassType>, ?componentTypes:Map<String, haxe.macro.Type.ClassType>):Void {
+        // Dynamic renderer (hot reload): the static Swift↔C bridge is entirely
+        // bypassed — the DynamicView renderer drives everything through the
+        // ViewNode bridge, and actions dispatch straight to the live tree's
+        // closures. So we suppress the static bridge files (which would also
+        // clash: duplicate haxe_bridge_invoke_action, references to an AppState
+        // that isn't generated when there's no @:state).
+        var dynamicMode = Context.defined("sui_hot_reload");
         var className = cls.name;
         var appName = className;
         var bundleId = 'com.example.${className.toLowerCase()}';
@@ -254,7 +270,7 @@ class SwiftGenerator {
         appSwift.add("@main\n");
         appSwift.add('struct ${className}App: App {\n');
         appSwift.add("    init() {\n");
-        if (needsRuntimeBridge) {
+        if (needsRuntimeBridge && !dynamicMode) {
             // Register the swift-side state callback BEFORE the
             // runtime boots. `HaxeRuntime.initialize()` calls
             // `haxe_bridge_init`, which itself constructs the
@@ -432,16 +448,26 @@ class SwiftGenerator {
         }
         sys.io.File.saveContent('$outputDir/ContentView.swift', contentWithModels.toString());
 
-        // Write bridge files if bridge is needed (explicit @:bridge or runtime closures)
-        if (needsRuntimeBridge || bridgeFunctions.length > 0) {
+        // Write bridge files if bridge is needed (explicit @:bridge or runtime
+        // closures) — but never in dynamic mode, where the ViewNode bridge and
+        // direct closure dispatch replace the static bridge entirely.
+        if ((needsRuntimeBridge || bridgeFunctions.length > 0) && !dynamicMode) {
             sys.io.File.saveContent('$outputDir/HaxeBridgeC.h', generateBridgeHeader(bridgeFunctions, needsRuntimeBridge));
             sys.io.File.saveContent('$outputDir/HaxeBridgeC.cpp', generateBridgeCpp(className, bridgeFunctions, needsRuntimeBridge));
             sys.io.File.saveContent('$outputDir/HaxeBridgeC.swift', generateBridgeSwift(className, bridgeFunctions, needsRuntimeBridge));
         }
 
-        // Generate AppState.swift for bridged apps with state
-        if (needsRuntimeBridge && stateDecls.length > 0) {
+        // Generate AppState.swift for bridged apps with state (static bridge only)
+        if (needsRuntimeBridge && stateDecls.length > 0 && !dynamicMode) {
             sys.io.File.saveContent('$outputDir/AppState.swift', generateAppState(stateDecls));
+        }
+
+        // Hot-reload / dynamic renderer: emit the runtime bootstrap. This file
+        // is the only per-app knowledge the dynamic bridge needs — the concrete
+        // app class to instantiate — so the macro (which knows it) generates it;
+        // the boot logic itself is a fixed framework template.
+        if (Context.defined("sui_hot_reload")) {
+            sys.io.File.saveContent('$outputDir/SuiBootC.cpp', generateBootCpp(cls));
         }
 
         // Generate Swift structs for ViewComponent subclasses
@@ -454,6 +480,42 @@ class SwiftGenerator {
                 }
             }
         }
+    }
+
+    /** Emit the C bootstrap for a dynamic-render / hot-reload build.
+
+        Boots the hxcpp runtime once, instantiates the concrete app, and
+        registers it with `ViewNodeBridge` so native renderers can traverse the
+        tree through the C bridge. The app class is the only per-app knowledge;
+        instantiation uses the direct hxcpp symbol (as the static bridge does),
+        which is more robust than reflection and forces the app + ViewNodeBridge
+        symbols to be linked. Mirrors the boot sequence of `haxe_bridge_init`. **/
+    static function generateBootCpp(cls:haxe.macro.Type.ClassType):String {
+        var name = cls.name;
+        var headerPath = cls.pack.length > 0 ? cls.pack.join("/") + "/" + name + ".h" : name + ".h";
+        var cppSym = "::" + (cls.pack.length > 0 ? cls.pack.join("::") + "::" : "") + name + "_obj";
+        var buf = new StringBuf();
+        buf.add("// AUTO-GENERATED by sui.macros.SwiftGenerator — do not edit.\n");
+        buf.add("// Runtime bootstrap for the dynamic (hot-reload) renderer:\n");
+        buf.add("// boots hxcpp, builds the app, hands it to ViewNodeBridge.\n");
+        buf.add("#include <hxcpp.h>\n");
+        buf.add('#include <$headerPath>\n');
+        buf.add("#include <sui/runtime/ViewNodeBridge.h>\n\n");
+        buf.add("extern \"C\" void viewnode_boot(void) {\n");
+        buf.add("    static bool _hxcppBooted = false;\n");
+        buf.add("    int dummy = 0;\n");
+        buf.add("    hx::SetTopOfStack(&dummy, true);\n");
+        buf.add("    try {\n");
+        buf.add("        if (!_hxcppBooted) { hx::Boot(); __boot_all(); _hxcppBooted = true; }\n");
+        buf.add('        auto app = $cppSym::__new();\n');
+        buf.add("        ::sui::runtime::ViewNodeBridge_obj::setApp(app);\n");
+        buf.add("    } catch (::Dynamic _e) {\n");
+        buf.add('        fprintf(stderr, "[sui] viewnode_boot: Haxe exception during boot\\n");\n');
+        buf.add("    } catch (...) {\n");
+        buf.add('        fprintf(stderr, "[sui] viewnode_boot: C++ exception during boot\\n");\n');
+        buf.add("    }\n");
+        buf.add("}\n");
+        return buf.toString();
     }
 
     /** Rewrite the bare state names produced by the one surviving

--- a/src/sui/runtime/ViewNodeBridge.hx
+++ b/src/sui/runtime/ViewNodeBridge.hx
@@ -12,7 +12,12 @@ import sui.modifiers.ViewModifier;
 
     Used by `mui watch` for hot reload — the native host stays running
     while the .cppia script is reloaded with new view code.
+
+    `@:keep` — every method here is reached only from the C bridge via
+    reflection, so DCE would otherwise strip the class in a dynamic-render
+    build whose Haxe never references it directly.
 **/
+@:keep
 class ViewNodeBridge {
     /** The root view tree, rebuilt on each reload. **/
     static var _root:View = null;
@@ -31,6 +36,25 @@ class ViewNodeBridge {
         if (_app != null) {
             _root = _app.body();
         }
+    }
+
+    /** Optional per-frame delegate: pumps an external source (e.g. a WebSocket
+        queue) on the main thread and reports whether the tree should rebuild. **/
+    static var _poll:Void->Bool = null;
+
+    /** Register the poll delegate (called by a dynamic app that streams its UI
+        from a live source rather than a fixed body()). **/
+    public static function setPoll(f:Void->Bool):Void {
+        _poll = f;
+    }
+
+    /** Pump the poll delegate and rebuild if it reports a change. Returns true
+        when the tree changed, so the native host can trigger a re-render. **/
+    public static function poll():Bool {
+        if (_poll == null) return false;
+        var changed = _poll();
+        if (changed) rebuild();
+        return changed;
     }
 
     /** Get the root view node. Returns an opaque pointer. **/
@@ -158,5 +182,18 @@ class ViewNodeBridge {
         if (node == null) return -1;
         var id:Dynamic = Reflect.field(node, "actionId");
         return id != null ? cast(id, Int) : -1;
+    }
+
+    /** Invoke a Button's action closure directly.
+
+        The static bridge routes taps through an integer id into the Callbacks
+        store because a Haxe closure captured by a Swift/ARC closure is invisible
+        to the hxcpp GC. The dynamic renderer has no such problem: it holds the
+        live view tree (`_root`, a GC root), so the closure sitting on the node
+        stays reachable. So we just call it — no id, no Callbacks indirection. **/
+    public static function invokeButtonAction(node:View):Void {
+        if (node == null) return;
+        var action:Dynamic = Reflect.field(node, "action");
+        if (action != null) action();
     }
 }

--- a/src/sui/runtime/ViewNodeBridge.hx
+++ b/src/sui/runtime/ViewNodeBridge.hx
@@ -57,6 +57,19 @@ class ViewNodeBridge {
         return changed;
     }
 
+    /** Optional sink for input edits: a native control (TextField, Toggle…)
+        writes a value at a data-model path back into the app. **/
+    static var _dataSink:(String, String) -> Void = null;
+
+    public static function setDataSink(f:(String, String) -> Void):Void {
+        _dataSink = f;
+    }
+
+    /** Called from the C bridge when a native input changes. **/
+    public static function setData(path:String, value:String):Void {
+        if (_dataSink != null) _dataSink(path, value);
+    }
+
     /** Get the root view node. Returns an opaque pointer. **/
     public static function getRoot():View {
         return _root;

--- a/src/sui/runtime/ViewNodeBridge.hx
+++ b/src/sui/runtime/ViewNodeBridge.hx
@@ -70,6 +70,18 @@ class ViewNodeBridge {
         if (_dataSink != null) _dataSink(path, value);
     }
 
+    /** The theme accent (e.g. a surface's primaryColor, hex) that the native
+        host tints controls with. "" means use the platform default. **/
+    static var _accent:String = "";
+
+    public static function setAccent(hex:String):Void {
+        _accent = hex != null ? hex : "";
+    }
+
+    public static function getAccent():String {
+        return _accent;
+    }
+
     /** Get the root view node. Returns an opaque pointer. **/
     public static function getRoot():View {
         return _root;

--- a/src/sui/runtime/ViewNodeBridge.hx
+++ b/src/sui/runtime/ViewNodeBridge.hx
@@ -82,6 +82,20 @@ class ViewNodeBridge {
         return _accent;
     }
 
+    /** Optional sink for renderer-originated actions carrying an extra context
+        as JSON (e.g. a Board drop's {card, lane, index}). **/
+    static var _actionSink:(String, String) -> Void = null;
+
+    public static function setActionSink(f:(String, String) -> Void):Void {
+        _actionSink = f;
+    }
+
+    /** Called from the C bridge when the renderer fires an action (name + a JSON
+        extra-context object). **/
+    public static function fireAction(name:String, extraJson:String):Void {
+        if (_actionSink != null) _actionSink(name, extraJson);
+    }
+
     /** Get the root view node. Returns an opaque pointer. **/
     public static function getRoot():View {
         return _root;

--- a/tools/cli/Build.hx
+++ b/tools/cli/Build.hx
@@ -462,12 +462,19 @@ class Build {
                     packages.push({url: pkg.url, from: pkg.from, product: pkg.product});
                 }
             }
+            var frameworks:Array<String> = null;
+            if (json.frameworks != null) {
+                frameworks = [];
+                var fw:Array<Dynamic> = json.frameworks;
+                for (f in fw) frameworks.push(Std.string(f));
+            }
             return {
                 appName: json.appName,
                 bundleIdentifier: json.bundleIdentifier,
                 bundleIdPrefix: json.bundleIdPrefix != null ? json.bundleIdPrefix : "com.example",
                 teamId: json.teamId,
                 swiftPackages: packages,
+                frameworks: frameworks,
             };
         }
 
@@ -678,15 +685,30 @@ class Build {
 ';
         }
 
+        // Compose the target settings: the native-bridge scaffold (bridging
+        // header + hxcpp static lib) plus any system frameworks the *app*
+        // declares in sui.json — dependencies belong to the app, not the core.
+        var ldflags:Array<String> = [];
+        if (nativeBridge) {
+            ldflags.push("-lhaxe");
+            ldflags.push("-lc++");
+        }
+        if (config.frameworks != null)
+            for (fw in config.frameworks) {
+                ldflags.push("-framework");
+                ldflags.push(fw);
+            }
         var bridge = "";
         if (nativeBridge) {
-            bridge = '      SWIFT_OBJC_BRIDGING_HEADER: Sources/SuiBridging.h
+            bridge += '      SWIFT_OBJC_BRIDGING_HEADER: Sources/SuiBridging.h
       LIBRARY_SEARCH_PATHS:
         - "$$(PROJECT_DIR)/lib"
-      OTHER_LDFLAGS:
-        - "-lhaxe"
-        - "-lc++"
 ';
+        }
+        if (ldflags.length > 0) {
+            bridge += "      OTHER_LDFLAGS:\n";
+            for (f in ldflags)
+                bridge += '        - "$f"\n';
         }
 
         var packagesBlock = "";
@@ -731,6 +753,9 @@ typedef ProjectConfig = {
     bundleIdPrefix:String,
     ?teamId:String,
     ?swiftPackages:Array<SwiftPackage>,
+    /** System frameworks the app links (e.g. ["AVKit"]) — declared per-app in
+        sui.json, not baked into the framework. */
+    ?frameworks:Array<String>,
 }
 
 typedef SwiftPackage = {

--- a/tools/cli/Build.hx
+++ b/tools/cli/Build.hx
@@ -82,6 +82,9 @@ class Build {
             Sys.setCwd(cwd);
             // Pass platform define for conditional compilation (#if sui_ios, #if sui_macos, #if sui_visionos)
             var haxeArgs = ["build.hxml", "-D", 'sui_$platform'];
+            // Dynamic renderer: SwiftGenerator emits SuiBootC.cpp and force-keeps
+            // the bridge classes only under this define.
+            if (hotReload) { haxeArgs.push("-D"); haxeArgs.push("sui_hot_reload"); }
             // For non-macOS targets, tell hxcpp to cross-compile for the correct platform
             if (platform == "ios") {
                 haxeArgs.push("-D");
@@ -109,8 +112,12 @@ class Build {
 
         // Auto-detect bridge app: macro generates HaxeBridgeC.cpp when bridge is needed
         var isBridgeApp = FileSystem.exists('$swiftGenDir/HaxeBridgeC.cpp');
+        // The dynamic (hot-reload) renderer needs the same native-bridge scaffold
+        // — hxcpp static lib + a compiled C bridge — even when the app has no
+        // action closures (so no HaxeBridgeC.cpp). Treat both the same way.
+        var nativeBridge = isBridgeApp || hotReload;
 
-        if (isBridgeApp) {
+        if (nativeBridge) {
             ensureDirectory('$buildDir/lib');
 
             if (needsRecompile || !FileSystem.exists('$buildDir/lib/libhaxe.a')) {
@@ -166,22 +173,38 @@ class Build {
                 clangArgs.push("-isysroot");
                 clangArgs.push(getSdkPath(sdk));
             }
-            clangArgs.push('$swiftGenDir/HaxeBridgeC.cpp');
-            clangArgs.push("-o");
-            clangArgs.push('$buildDir/lib/HaxeBridgeC.o');
-            var clangResult = Sys.command("clang++", clangArgs);
-            if (clangResult != 0) {
-                Sys.println("Error: C++ bridge compilation failed.");
-                Sys.exit(1);
+            // The C++ bridge sources to compile into the static library:
+            //   - HaxeBridgeC.cpp   — static bridge (@:expose fns, action dispatch)
+            //   - ViewNodeBridgeC.cpp + SuiBootC.cpp — dynamic renderer + bootstrap
+            var libPath = getLibPath();
+            var bridgeSources:Array<{src:String, obj:String}> = [];
+            if (isBridgeApp)
+                bridgeSources.push({src: '$swiftGenDir/HaxeBridgeC.cpp', obj: '$buildDir/lib/HaxeBridgeC.o'});
+            if (hotReload) {
+                bridgeSources.push({src: '$libPath/runtime/ViewNodeBridgeC.cpp', obj: '$buildDir/lib/ViewNodeBridgeC.o'});
+                bridgeSources.push({src: '$swiftGenDir/SuiBootC.cpp', obj: '$buildDir/lib/SuiBootC.o'});
             }
-
-            // Add bridge object to the static library
-            Sys.command("ar", ["rcs", '$buildDir/lib/libhaxe.a', '$buildDir/lib/HaxeBridgeC.o']);
+            for (bs in bridgeSources) {
+                if (!FileSystem.exists(bs.src)) {
+                    Sys.println('Error: expected C++ bridge source missing: ${bs.src}');
+                    Sys.exit(1);
+                }
+                var cargs = clangArgs.copy();
+                cargs.push(bs.src);
+                cargs.push("-o");
+                cargs.push(bs.obj);
+                if (Sys.command("clang++", cargs) != 0) {
+                    Sys.println('Error: C++ bridge compilation failed for ${bs.src}.');
+                    Sys.exit(1);
+                }
+                // Add the bridge object to the static library
+                Sys.command("ar", ["rcs", '$buildDir/lib/libhaxe.a', bs.obj]);
+            }
         }
 
         // Step N: Assemble Xcode project
-        var stepNum = isBridgeApp ? 3 : 2;
-        var totalSteps = isBridgeApp ? 4 : 3;
+        var stepNum = nativeBridge ? 3 : 2;
+        var totalSteps = nativeBridge ? 4 : 3;
         Sys.println('[$stepNum/$totalSteps] Assembling Xcode project...');
 
         // Copy Swift files (skip .cpp/.h for bridge — they're in the static lib)
@@ -203,11 +226,25 @@ class Build {
             copyHotReloadFiles(buildDir);
         }
 
+        // Umbrella bridging header: Xcode exposes exactly one bridging header to
+        // Swift, but a hot-reload app may need both the static bridge (actions)
+        // and the dynamic ViewNode bridge. Generate one that includes whichever
+        // headers are present.
+        if (nativeBridge) {
+            var umbrella = new StringBuf();
+            umbrella.add("// AUTO-GENERATED — Swift ↔ hxcpp bridging umbrella header.\n");
+            if (FileSystem.exists('$buildDir/Sources/HaxeBridgeC.h'))
+                umbrella.add("#include \"HaxeBridgeC.h\"\n");
+            if (FileSystem.exists('$buildDir/Sources/ViewNodeBridgeC.h'))
+                umbrella.add("#include \"ViewNodeBridgeC.h\"\n");
+            File.saveContent('$buildDir/Sources/SuiBridging.h', umbrella.toString());
+        }
+
         // Copy user-provided Swift files from swift/ directory
         copyUserSwiftFiles(cwd, buildDir);
 
         // Generate project.yml
-        File.saveContent('$buildDir/project.yml', generateProjectYaml(config, platform, forDevice, isBridgeApp));
+        File.saveContent('$buildDir/project.yml', generateProjectYaml(config, platform, forDevice, nativeBridge));
 
         if (xcodeOnly) {
             runXcodegen(buildDir);
@@ -386,9 +423,11 @@ class Build {
             var content = File.getContent(contentView);
             // Replace the body of MainScreen with HotReloadRootView
             // The generated ContentView has a MainScreen() function — wrap it
+            // App.swift instantiates ContentView() — replace the generated
+            // static view with one that hosts the runtime DynamicView renderer.
             var hotReloadWrapper = "// Hot reload mode — uses DynamicView renderer\n"
                 + "import SwiftUI\n\n"
-                + "struct MainScreen: View {\n"
+                + "struct ContentView: View {\n"
                 + "    var body: some View {\n"
                 + "        HotReloadRootView()\n"
                 + "    }\n"
@@ -627,7 +666,7 @@ class Build {
         };
     }
 
-    static function generateProjectYaml(config:ProjectConfig, platform:String, forDevice:Bool, isBridgeApp:Bool = false):String {
+    static function generateProjectYaml(config:ProjectConfig, platform:String, forDevice:Bool, nativeBridge:Bool = false):String {
         var pk = platformKey(platform);
         var dt = deploymentTarget(platform);
 
@@ -640,8 +679,8 @@ class Build {
         }
 
         var bridge = "";
-        if (isBridgeApp) {
-            bridge = '      SWIFT_OBJC_BRIDGING_HEADER: Sources/HaxeBridgeC.h
+        if (nativeBridge) {
+            bridge = '      SWIFT_OBJC_BRIDGING_HEADER: Sources/SuiBridging.h
       LIBRARY_SEARCH_PATHS:
         - "$$(PROJECT_DIR)/lib"
       OTHER_LDFLAGS:


### PR DESCRIPTION
Completes sui's (previously incomplete) **dynamic renderer**: instead of compiling `body()` to Swift ahead of time, the view tree is walked at **runtime** through a C `ViewNode` bridge and `DynamicView.swift` rebuilds SwiftUI from it — no per-view codegen. Enabled with `sui build --watch`.

This makes sui usable as a host for a UI that isn't known at compile time (hot reload, or a renderer driven by a live protocol — it's what rsx2ui's native A2UI renderer is built on).

## What's in it

- **Wiring** (`81683f8`): direct-symbol C bridge (the prior `Type_obj` reflection API doesn't exist), generic `SuiBootC.cpp` bootstrap, `@:keep` + `getModule` past DCE, native-bridge build path in `Build.hx`, weak `__hxcpp_lib_main` stub, `examples/dynamic-hello`.
- **Interaction**: two-way inputs with stable node identity (focus preserved), direct button-action dispatch.
- **Catalog** rendered by `DynamicView`: Slider, Icon, ChoicePicker (single/multi), Tabs, Modal, Canvas (native draw-op interpreter), Image, Video, Board (drag-and-drop).
- **Theming**: `.tint` from a theme accent; Canvas resolves every colour token from the surface theme.
- **Transitions**: animated rebuilds; Board cards FLIP-slide between lanes.
- **Per-app frameworks**: `sui.json` `"frameworks": [...]` (no framework hardcoded in the core).
- **Docs**: `docs/dynamic-renderer.md` + sidebar + CLI `--watch`.

The static bridge ([Bridge](../blob/dynamic-renderer/docs/bridge.md)) is untouched; this is its runtime counterpart, suppressed-static in `--watch` mode.

Proven end-to-end on macOS against live rsx2ui demos (counter/form/widgets/tabs/canvas/board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brah2z1PGqeYhq8gfuhbrE