### PR TITLE
iOS: local-network Info.plist entry + video audio session

### DIFF
--- a/runtime/DynamicView.swift
+++ b/runtime/DynamicView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Foundation
 import AVKit
+import AVFoundation
 
 /// Recursively renders a Haxe view tree at runtime.
 /// Used by `mui watch` for hot reload — the Swift host stays running
@@ -495,7 +496,17 @@ struct DynamicVideo: View {
     var body: some View {
         Group {
             if let player = player {
-                VideoPlayer(player: player).frame(minHeight: 220)
+                VideoPlayer(player: player)
+                    .frame(minHeight: 220)
+                    .onAppear {
+                        // iOS won't start playback without an active playback
+                        // audio session — macOS doesn't require it.
+                        #if os(iOS)
+                        try? AVAudioSession.sharedInstance().setCategory(.playback)
+                        try? AVAudioSession.sharedInstance().setActive(true)
+                        #endif
+                        player.play()
+                    }
             } else {
                 Text("Vidéo indisponible").foregroundStyle(.secondary)
             }

--- a/tools/cli/Build.hx
+++ b/tools/cli/Build.hx
@@ -711,6 +711,15 @@ class Build {
                 bridge += '        - "$f"\n';
         }
 
+        // iOS/visionOS: connecting to a device's LAN (e.g. a local dev server)
+        // triggers the iOS 14+ local-network privacy prompt; without a usage
+        // description the connection is denied. macOS doesn't gate this.
+        var networking = "";
+        if (platform != "macos") {
+            networking = '      INFOPLIST_KEY_NSLocalNetworkUsageDescription: "Connect to a local development server on your network."
+';
+        }
+
         var packagesBlock = "";
         var depsBlock = "    dependencies: []\n";
         if (config.swiftPackages != null && config.swiftPackages.length > 0) {
@@ -743,7 +752,7 @@ targets:
       INFOPLIST_KEY_UILaunchScreen_Generation: true
       INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
       INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-$signing$bridge$depsBlock';
+$networking$signing$bridge$depsBlock';
     }
 }
 


### PR DESCRIPTION
Two fixes surfaced running the dynamic renderer on a real iPhone:

- **Build.hx**: iOS/visionOS builds now emit `NSLocalNetworkUsageDescription`, so an app connecting to a LAN dev server passes the iOS 14+ local-network privacy gate (macOS doesn't gate this). ATS isn't needed — hxWebSockets uses raw BSD sockets, which ATS doesn't cover.
- **DynamicVideo**: iOS won't start `AVPlayer` playback without an active `.playback` audio session (macOS doesn't require it) — set it on appear and autoplay.

Proven on a real iPhone (iPhone 13, iOS 26.3): the renderer connects over the LAN and video plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brah2z1PGqeYhq8gfuhbrE